### PR TITLE
feat(dex): Swagger 설정 및 도감 API 명세 초안 추가

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -3,8 +3,6 @@ name: Deploy to Dev EC2
 on:
   push:
     branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
   workflow_dispatch:
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
 	implementation 'org.flywaydb:flyway-core:11.7.1'
 	implementation 'org.flywaydb:flyway-database-postgresql:11.7.1'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/controller/BirdController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/controller/BirdController.java
@@ -101,6 +101,9 @@ public class BirdController {
 
         @Schema(description = "조류 설명", example = "전국 어디서나 흔하게 관찰되는 텃새입니다.")
         public String description;
+
+        @Schema(description = "조류 이미지 URL 목록", example = "[\"~~~.jpg\", \"~~~.png\"]")
+        public List<String> imageUrls;
     }
 
     @Schema(description = "분류학적 정보")

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/controller/BirdController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/controller/BirdController.java
@@ -1,0 +1,127 @@
+package org.devkor.apu.saerok_server.domain.dex.bird.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Birds API", description = "도감 기능 관련 API")
+@RestController
+@RequestMapping("${api_prefix}/birds")
+public class BirdController {
+
+    @GetMapping("/")
+    @Operation(
+            summary = "🛠 [미구현] 조류 목록 조회 및 검색",
+            description = "도감에 등록된 조류 목록을 조회하거나, 필터 조건 및 키워드를 이용해 검색할 수 있습니다.",
+            responses = @ApiResponse(
+                    responseCode = "200",
+                    description = "조류 목록 응답",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = BirdListResponse.class)))
+            )
+    )
+    public void getBirds(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(required = false) Integer page,
+            @Parameter(description = "페이지 크기", example = "20") @RequestParam(required = false) Integer size,
+            @Parameter(description = "검색 키워드 (한글 이름)") @RequestParam(required = false) String q,
+            @Parameter(description = "서식지 필터", example = "[\"FOREST\", \"WETLAND\"]") @RequestParam(required = false) List<String> habitat,
+            @Parameter(description = "크기 필터", example = "[\"SMALL\", \"MEDIUM\"]") @RequestParam(required = false) List<String> bodySize,
+            @Parameter(description = "계절 필터", example = "[\"SPRING\", \"SUMMER\"]") @RequestParam(required = false) List<String> season
+    ) {
+        // 미구현
+    }
+
+    @GetMapping("/{birdId}")
+    @Operation(
+            summary = "🛠 [미구현] 특정 조류 상세 조회",
+            description = "birdId를 기반으로 해당 조류의 상세 정보를 조회합니다.",
+            responses = @ApiResponse(
+                    responseCode = "200",
+                    description = "조류 상세 응답",
+                    content = @Content(schema = @Schema(implementation = BirdDetailResponse.class))
+            )
+    )
+    public void getBirdDetail() {
+        // 미구현
+    }
+
+    @GetMapping("/autocomplete")
+    @Operation(
+            summary = "🛠 [미구현] 조류 자동완성",
+            description = "조류 이름 검색을 위한 자동완성 제안을 반환합니다.",
+            responses = @ApiResponse(
+                    responseCode = "200",
+                    description = "자동완성 결과",
+                    content = @Content(schema = @Schema(implementation = BirdAutocompleteResponse.class))
+            )
+    )
+    public void getBirdAutocomplete(
+            @Parameter(description = "검색 키워드 (한글 이름)") @RequestParam String q
+    ) {
+        // 미구현
+    }
+
+    @Schema(description = "조류 목록 응답 DTO")
+    public static class BirdListResponse {
+        @Schema(description = "조류 ID", example = "1")
+        public Long id;
+
+        @Schema(description = "한글 이름", example = "까치")
+        public String koreanName;
+
+        @Schema(description = "학명", example = "Pica pica")
+        public String scientificName;
+
+        @Schema(description = "썸네일 이미지 URL", example = "https://example.com/images/bird-thumb.jpg")
+        public String thumbImageUrl;
+    }
+
+    @Schema(description = "조류 상세 응답 DTO")
+    public static class BirdDetailResponse {
+        @Schema(description = "조류 ID", example = "1")
+        public Long id;
+
+        @Schema(description = "한글 이름", example = "까치")
+        public String koreanName;
+
+        @Schema(description = "학명", example = "Pica pica")
+        public String scientificName;
+
+        @Schema(description = "분류학적 정보")
+        public BirdTaxonomy taxonomy;
+
+        @Schema(description = "조류 설명", example = "전국 어디서나 흔하게 관찰되는 텃새입니다.")
+        public String description;
+    }
+
+    @Schema(description = "분류학적 정보")
+    public static class BirdTaxonomy {
+        public String phylumEng;
+        public String phylumKor;
+        public String classEng;
+        public String classKor;
+        public String orderEng;
+        public String orderKor;
+        public String familyEng;
+        public String familyKor;
+        public String genusEng;
+        public String genusKor;
+        public String speciesEng;
+        public String speciesKor;
+    }
+
+    @Schema(description = "조류 자동완성 응답 DTO")
+    public static class BirdAutocompleteResponse {
+        @Schema(description = "추천 이름 리스트", example = "[\"까치\", \"까마귀\"]")
+        public List<String> suggestions;
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/system/controller/SystemController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/system/controller/SystemController.java
@@ -1,25 +1,43 @@
 package org.devkor.apu.saerok_server.system.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "System API", description = "시스템 상태 점검 관련 API")
 @RestController
-@RequestMapping("/api/v1/system")
+@RequestMapping("${api_prefix}/system")
 public class SystemController {
 
     @Value("${spring.profiles.active}")
     private String activeProfile;
 
     @GetMapping("/ping")
+    @Operation(
+            summary = "시스템 핑",
+            description = "시스템이 살아있는지 확인합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "정상 응답")
+            }
+    )
     public String ping() {
         return "pong from saerok-server";
     }
 
     @GetMapping("/profile")
+    @Operation(
+            summary = "서버 프로파일 확인",
+            description = "서버가 로컬 서버 설정인지, 개발 서버 설정인지, 운영 서버 설정인지 확인합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "정상 응답")
+            }
+    )
     public String getActiveProfile() {
-        return "현재 활성화된 프로필은: " + activeProfile + "입니다!";
+        return activeProfile;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,5 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 0
+
+api_prefix: /api/v1


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
API 명세 관리를 위해 Swagger를 설정하고, 도감 API 명세 초안을 추가했습니다.

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->
![image](https://github.com/user-attachments/assets/9c67499f-dfdb-45d3-a5bd-cdc083be2f5a)
이런 식으로 API 명세를 확인할 수 있으며, 아직 실제 구현하지 않고 명세만 있는 경우는 "미구현" 표시로 구분합니다.

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
@pizzazoa 
지금 BirdController 파일을 보시면 실제 구현은 없고 Swagger 명세만 만들어뒀습니다. 앞으로 개발할 때도 이런 식으로 "명세 만들어서 공유해서 의견 받고 -> 명세 확정해서 개발하기" 방법으로 할까 싶은데 어떠신가요??

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.