### PR TITLE
fix(ci): 배포 워크플로우 오류 수정

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -25,7 +25,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew test bootJar
 
       - name: Copy JAR to EC2
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

배포 직전 테스트할 때 ./gradlew build 대신 ./gradlew test bootJar 쓰도록 변경.
build를 쓰면 이상한 JAR 파일이 EC2로 전송되어서 기존 워크플로우대로 안 돌아감

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.