### PR TITLE
feat(db): 계절별 희귀도 우선순위 변경

### DIFF
--- a/src/main/resources/db/migration/V5__alter_rarity_priority.sql
+++ b/src/main/resources/db/migration/V5__alter_rarity_priority.sql
@@ -1,0 +1,9 @@
+-- 기존에는 새의 특정 계절 희귀도를 결정할 때 UNSPECIFIED를 RARE보다 우선시했는데, RARE를 우선시하도록 변경함
+
+UPDATE rarity_type
+SET priority = CASE code
+                   WHEN 'UNSPECIFIED' THEN -10
+                   WHEN 'RARE' THEN 0
+                   ELSE priority
+    END
+WHERE code IN ('UNSPECIFIED', 'RARE');

--- a/src/test/resources/db/migration/test/V4__bird_update_trigger.sql
+++ b/src/test/resources/db/migration/test/V4__bird_update_trigger.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION touch_bird_updated_at()
+RETURNS trigger AS $$
+BEGIN
+UPDATE bird
+SET updated_at = NOW()
+WHERE id = COALESCE(NEW.bird_id, OLD.bird_id);
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- bird_habitat → bird.updated_at
+DROP TRIGGER IF EXISTS trg_bird_habitat_touch ON bird_habitat;
+CREATE TRIGGER trg_bird_habitat_touch
+    AFTER INSERT OR UPDATE OR DELETE ON bird_habitat
+    FOR EACH ROW EXECUTE FUNCTION touch_bird_updated_at();
+
+-- bird_image → bird.updated_at
+DROP TRIGGER IF EXISTS trg_bird_image_touch ON bird_image;
+CREATE TRIGGER trg_bird_image_touch
+    AFTER INSERT OR UPDATE OR DELETE ON bird_image
+    FOR EACH ROW EXECUTE FUNCTION touch_bird_updated_at();
+
+-- bird_residency → bird.updated_at
+DROP TRIGGER IF EXISTS trg_bird_residency_touch ON bird_residency;
+CREATE TRIGGER trg_bird_residency_touch
+    AFTER INSERT OR UPDATE OR DELETE ON bird_residency
+    FOR EACH ROW EXECUTE FUNCTION touch_bird_updated_at();

--- a/src/test/resources/db/migration/test/V5__alter_rarity_priority.sql
+++ b/src/test/resources/db/migration/test/V5__alter_rarity_priority.sql
@@ -1,0 +1,9 @@
+-- 기존에는 새의 특정 계절 희귀도를 결정할 때 UNSPECIFIED를 RARE보다 우선시했는데, RARE를 우선시하도록 변경함
+
+UPDATE rarity_type
+SET priority = CASE code
+                   WHEN 'UNSPECIFIED' THEN -10
+                   WHEN 'RARE' THEN 0
+                   ELSE priority
+    END
+WHERE code IN ('UNSPECIFIED', 'RARE');


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

계절별 희귀도 우선순위를 변경함.
기존에는 COMMON > UNSPECIFIED > RARE 순이었는데, COMMON > RARE > UNSPECIFIED 순으로 변경.

예를 들어 어떤 새가 3월에는 드물고 4월에는 희귀도 미지정일 때, 기존에는 해당 새의 봄 희귀도는 "미지정"으로 결정됨.
이제부터는 해당 새의 봄 희귀도가 "드묾"으로 결정됨.

미지정은 "흔함과 드묾 사이의 희귀도"라기보다는 "흔한지 드문지 확실치 않다"고 보는 게 맞을 것 같아서 이렇게 변경했음

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.