### PR TITLE
feat(dex): 특정 조류 상세 정보 조회 API

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/api/BirdController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/api/BirdController.java
@@ -13,10 +13,7 @@ import org.devkor.apu.saerok_server.domain.dex.bird.application.BirdQueryService
 import org.devkor.apu.saerok_server.global.exception.ErrorResponse;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -52,7 +49,7 @@ public class BirdController {
 
     @GetMapping("/{birdId}")
     @Operation(
-            summary = "🛠 [미구현] 특정 조류 상세 조회",
+            summary = "특정 조류 상세 조회",
             description = "birdId를 기반으로 해당 조류의 상세 정보를 조회합니다.",
             responses = @ApiResponse(
                     responseCode = "200",
@@ -60,9 +57,10 @@ public class BirdController {
                     content = @Content(schema = @Schema(implementation = BirdDetailResponse.class))
             )
     )
-    public void getBirdDetail() {
-        // HINT: birdQueryService에서 만든 메서드를 호출하세요.
-        // 현재 이 메서드의 파라미터나 반환형도 수정이 필요할 겁니다.
+    public ResponseEntity<BirdDetailResponse> getBirdDetail(
+            @Parameter(description = "조회할 조류의 ID", example = "1") @PathVariable Long birdId) {
+        BirdDetailResponse response = birdQueryService.getBirdDetailResponse(birdId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/autocomplete")

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/api/BirdController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/api/BirdController.java
@@ -51,11 +51,18 @@ public class BirdController {
     @Operation(
             summary = "특정 조류 상세 조회",
             description = "birdId를 기반으로 해당 조류의 상세 정보를 조회합니다.",
-            responses = @ApiResponse(
+            responses = {
+                    @ApiResponse(
                     responseCode = "200",
                     description = "조류 상세 응답",
                     content = @Content(schema = @Schema(implementation = BirdDetailResponse.class))
-            )
+            ),
+                    @ApiResponse(
+                    responseCode = "404",
+                    description = "조류를 찾을 수 없습니다",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public ResponseEntity<BirdDetailResponse> getBirdDetail(
             @Parameter(description = "조회할 조류의 ID", example = "1") @PathVariable Long birdId) {
@@ -65,7 +72,7 @@ public class BirdController {
 
     @GetMapping("/autocomplete")
     @Operation(
-            summary = "🛠 [미구현] 조류 자동완성",
+            summary = "조류 자동완성",
             description = "조류 이름 검색을 위한 자동완성 제안을 반환합니다.",
             responses = @ApiResponse(
                     responseCode = "200",

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/BirdQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/BirdQueryService.java
@@ -10,6 +10,7 @@ import org.devkor.apu.saerok_server.domain.dex.bird.domain.service.SizeCategoryS
 import org.devkor.apu.saerok_server.domain.dex.bird.query.view.BirdProfileView;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.mapper.BirdProfileViewMapper;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.repository.BirdProfileViewRepository;
+import org.devkor.apu.saerok_server.global.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,7 +43,7 @@ public class BirdQueryService {
 
     public BirdDetailResponse getBirdDetailResponse(Long birdId) {
         BirdProfileView birdProfileView = birdProfileViewRepository.findById(birdId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 조류를 찾을 수 없습니다: " + birdId));
+                .orElseThrow(() -> new NotFoundException("Bird", "id", birdId));
         BirdDetailResponse response = birdProfileViewMapper.toBirdDetailResponse(birdProfileView);
         response.sizeCategory = sizeCategoryService.getSizeCategory(birdProfileView).getLabel();
         return response;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/BirdQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/BirdQueryService.java
@@ -43,7 +43,9 @@ public class BirdQueryService {
     public BirdDetailResponse getBirdDetailResponse(Long birdId) {
         BirdProfileView birdProfileView = birdProfileViewRepository.findById(birdId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 조류를 찾을 수 없습니다: " + birdId));
-        return birdProfileViewMapper.toBirdDetailResponse(birdProfileView, sizeCategoryService);
+        BirdDetailResponse response = birdProfileViewMapper.toBirdDetailResponse(birdProfileView);
+        response.sizeCategory = sizeCategoryService.getSizeCategory(birdProfileView).getLabel();
+        return response;
     }
     // HINT: 여기에 getBirdDetailResponse 메서드를 만들고,
     // birdProfileViewRepository로 적절한 BirdProfileView를 가져오세요.

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/BirdQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/BirdQueryService.java
@@ -2,9 +2,11 @@ package org.devkor.apu.saerok_server.domain.dex.bird.application;
 
 import lombok.RequiredArgsConstructor;
 import org.devkor.apu.saerok_server.domain.dex.bird.api.dto.response.BirdChangesResponse;
+import org.devkor.apu.saerok_server.domain.dex.bird.api.dto.response.BirdDetailResponse;
 import org.devkor.apu.saerok_server.domain.dex.bird.api.dto.response.BirdFullSyncResponse;
 import org.devkor.apu.saerok_server.domain.dex.bird.domain.entity.Bird;
 import org.devkor.apu.saerok_server.domain.dex.bird.domain.repository.BirdRepository;
+import org.devkor.apu.saerok_server.domain.dex.bird.domain.service.SizeCategoryService;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.view.BirdProfileView;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.mapper.BirdProfileViewMapper;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.repository.BirdProfileViewRepository;
@@ -21,6 +23,7 @@ public class BirdQueryService {
 
     private final BirdProfileViewRepository birdProfileViewRepository;
     private final BirdProfileViewMapper birdProfileViewMapper;
+    private final SizeCategoryService sizeCategoryService;
 
     public BirdFullSyncResponse getBirdFullSyncResponse() {
         List<BirdProfileView> birdProfileViews = birdProfileViewRepository.findAll();
@@ -37,6 +40,11 @@ public class BirdQueryService {
         return response;
     }
 
+    public BirdDetailResponse getBirdDetailResponse(Long birdId) {
+        BirdProfileView birdProfileView = birdProfileViewRepository.findById(birdId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 조류를 찾을 수 없습니다: " + birdId));
+        return birdProfileViewMapper.toBirdDetailResponse(birdProfileView, sizeCategoryService);
+    }
     // HINT: 여기에 getBirdDetailResponse 메서드를 만들고,
     // birdProfileViewRepository로 적절한 BirdProfileView를 가져오세요.
     // 그리고 birdProfileViewMapper로 birdProfileView를 BirdDetailResponse 형태로 변환해서 return하면 됩니다.

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/mapper/BirdProfileViewMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/mapper/BirdProfileViewMapper.java
@@ -21,8 +21,8 @@ public interface BirdProfileViewMapper {
     @Mapping(source = "name.scientificName", target = "scientificName")
     @Mapping(source = "description.description", target = "description")
     @Mapping(source = "images", target = "imageUrls", qualifiedByName = "extractImageUrls")
-    @Mapping(target = "sizeCategory", expression = "java(sizeCategoryService.getSizeCategory(view).getLabel())")
-    BirdDetailResponse toBirdDetailResponse(BirdProfileView view, @Context SizeCategoryService sizeCategoryService);
+    @Mapping(target = "sizeCategory", ignore = true)
+    BirdDetailResponse toBirdDetailResponse(BirdProfileView view);
 
     @Named("extractImageUrls")
     default List<String> extractImageUrls(List<BirdProfileView.Image> images) {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/mapper/BirdProfileViewMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/mapper/BirdProfileViewMapper.java
@@ -1,9 +1,10 @@
 package org.devkor.apu.saerok_server.domain.dex.bird.query.mapper;
 
+import org.devkor.apu.saerok_server.domain.dex.bird.api.dto.response.BirdDetailResponse;
 import org.devkor.apu.saerok_server.domain.dex.bird.api.dto.response.BirdFullSyncResponse;
+import org.devkor.apu.saerok_server.domain.dex.bird.domain.service.SizeCategoryService;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.view.BirdProfileView;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingConstants;
+import org.mapstruct.*;
 
 import java.util.List;
 
@@ -16,6 +17,20 @@ public interface BirdProfileViewMapper {
 
     List<BirdFullSyncResponse.BirdProfileItem> toDtoList(List<BirdProfileView> birdProfileViews);
 
+    @Mapping(source = "name.koreanName", target = "koreanName")
+    @Mapping(source = "name.scientificName", target = "scientificName")
+    @Mapping(source = "description.description", target = "description")
+    @Mapping(source = "images", target = "imageUrls", qualifiedByName = "extractImageUrls")
+    @Mapping(target = "sizeCategory", expression = "java(sizeCategoryService.getSizeCategory(view).getLabel())")
+    BirdDetailResponse toBirdDetailResponse(BirdProfileView view, @Context SizeCategoryService sizeCategoryService);
+
+    @Named("extractImageUrls")
+    default List<String> extractImageUrls(List<BirdProfileView.Image> images) {
+        if (images == null) return List.of();
+        return images.stream()
+                .map(BirdProfileView.Image::getS3Url)
+                .toList();
+    }
     // HINT: 여기에 BirdProfileView 타입을 BirdDetailResponse 타입으로 변환해주는 메서드를 정의하세요.
     // MapStruct라는 걸 찾아보시면 도움이 될 겁니다.
 
@@ -24,4 +39,5 @@ public interface BirdProfileViewMapper {
     }
 
     List<Long> toIdList(List<BirdProfileView> birdProfileViews);
+
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.devkor.apu.saerok_server.global.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,5 +14,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.
                 internalServerError().
                 body(error);
+    }
+    
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(error);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/exception/NotFoundException.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/exception/NotFoundException.java
@@ -1,0 +1,20 @@
+package org.devkor.apu.saerok_server.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    
+    private final String resourceName;
+    
+    private final String fieldName;
+    
+    private final Object fieldValue;
+    
+    public NotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
+        this.resourceName = resourceName;
+        this.fieldName = fieldName;
+        this.fieldValue = fieldValue;
+    }
+}


### PR DESCRIPTION
id로 특정 조류의 상세정보를 조회하는 GET api입니다

## 📝 요약(Summary)

BirdController, BirdQueryService, BirdProfileViewMapper 각각에 필요한 메서드들을 구현했습니다.

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->

## 💬 공유사항

@soonduck-dreams 
Mapper를 보시면, 
sizeCategory 정보를 매핑할 때 SizeCategoryService를 이용하기 위해 오버로드 대신 context로 해결했습니다.
이렇게 하는 게 더 깔끔한 것 같아서 해봤는데, 다른 해결법이 있다거나 다른 방식으로 했으면 좋겠다거나 하시다면 말씀해주세요.

추후 에러 핸들러도 추가할 예정입니다(아마 400번대 에러로 처리할 듯 합니다).

결과는 어제 보여드린 것처럼 잘 나오더라구요 :)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.