### PR TITLE
feat(dex): 도감 검색/조회 API에 정렬 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,17 +61,9 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-// QueryDSL 의존성 설정
-def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
-
 tasks.withType(JavaCompile).configureEach {
-	options.generatedSourceOutputDirectory.set(querydslDir)
-}
-
-sourceSets {
-	main.java.srcDirs += [ querydslDir ]
-}
-
-clean.doLast {
-	file(querydslDir).deleteDir()
+	options.compilerArgs += [
+			'-Amapstruct.incrementalProcessing=true',
+			'-Amapstruct.suppressGeneratorTimestamp=true'
+	]
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/api/BirdController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/api/BirdController.java
@@ -2,16 +2,15 @@ package org.devkor.apu.saerok_server.domain.dex.bird.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.devkor.apu.saerok_server.domain.dex.bird.api.dto.response.*;
 import org.devkor.apu.saerok_server.domain.dex.bird.application.BirdQueryService;
 import org.devkor.apu.saerok_server.domain.dex.bird.application.dto.BirdSearchCommand;
+import org.devkor.apu.saerok_server.global.exception.BadRequestException;
 import org.devkor.apu.saerok_server.global.exception.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,53 +30,72 @@ public class BirdController {
     @Operation(
             summary = "도감 조회/검색",
             description = """
-            도감에 등록된 조류 목록을 조회하거나, 검색 키워드 및 다양한 필터를 조합해 검색할 수 있습니다.
-            
-            현재는 가나다순 정렬로 제공합니다. 필요에 따라 업데이트할 예정입니다.
-            
-            ✅ **일반 조회**
-            - `q`를 비우면 전체 도감 목록을 조회합니다.
-            
-            🔍 **검색**
-            - `q`에 검색 키워드를 입력하면 해당 단어를 포함하는 조류를 찾습니다.
-            - `habitats`, `sizeCategories`, `seasons`에 필터를 추가하면 조건에 따라 결과를 좁힙니다.
-            - **같은 필터 항목 내에서는 OR**, **다른 필터 항목 간에는 AND**로 적용됩니다.
-            
-            📄 **페이징 (선택)**
-            - `page`는 1부터 시작합니다.
-            - `page`와 `size`는 둘 다 제공해야 하며, 하나만 제공 시 Bad Request가 발생합니다.
-            - 생략하면 전체 결과를 반환합니다.
-            
-            🔧 **쿼리 파라미터 예시**
-            - `habitats=forest&habitats=marine&sizeCategories=small&seasons=summer`
-            - List 타입 필터는 파라미터를 중복 선언하여 입력합니다.
-            
-            📌 **허용된 필터 값 목록** (대소문자 구분 없음, 잘못된 값 입력 시 Bad Request)
-            
-            - **habitats**:
-                - mudflat (갯벌)
-                - farmland (경작지/들판)
-                - forest (산림/계곡)
-                - marine (해양)
-                - residential (거주지역)
-                - plains_forest (평지숲)
-                - river_lake (하천/호수)
-                - artificial (인공시설)
-                - cave (동굴)
-                - wetland (습지)
-                - others (기타)
-            
-            - **sizeCategories**:
-                - xsmall, small, medium, large
-            
-            - **seasons**:
-                - spring, summer, autumn, winter
-            """,
-            responses = @ApiResponse(
-                    responseCode = "200",
-                    description = "도감 조회/검색 응답",
-                    content = @Content(schema = @Schema(implementation = BirdSearchResponse.class))
-            )
+        도감에 등록된 조류 목록을 조회하거나, 검색 키워드 및 다양한 필터를 조합해 검색할 수 있습니다.
+        
+        ✅ **일반 조회**
+        - `q`를 비우면 전체 도감 목록을 조회합니다.
+
+        🔍 **검색**
+        - `q`에 검색 키워드를 입력하면 해당 단어를 포함하는 조류를 찾습니다.
+        - `habitats`, `sizeCategories`, `seasons`에 필터를 추가하면 조건에 따라 결과를 좁힙니다.
+        - **같은 필터 항목 내에서는 OR**, **다른 필터 항목 간에는 AND**로 적용됩니다.
+
+        📄 **페이징 (선택)**
+        - `page`는 1부터 시작합니다.
+        - `page`와 `size`는 둘 다 제공해야 하며, 하나만 제공 시 Bad Request가 발생합니다.
+        - 생략하면 전체 결과를 반환합니다.
+
+        🔽 **정렬 (선택)**
+        - `sort`와 `sortDir`을 조합하여 정렬 기준을 설정할 수 있습니다.
+        - 대소문자 구분 없이 입력 가능합니다.
+        - 기본값: `sort=id`, `sortDir=asc`
+        
+        - `sort` 허용 값:
+            - `id` (등록 순)
+            - `korean_name` (이름 가나다순)
+            - `body_length` (체장 기준)
+        
+        - `sortDir` 허용 값:
+            - `asc` (오름차순)
+            - `desc` (내림차순)
+
+        🔧 **쿼리 파라미터 예시**
+        - `habitats=forest&habitats=marine&sizeCategories=small&seasons=summer`
+        - List 타입 필터는 파라미터를 중복 선언하여 입력합니다.
+
+        📌 **허용된 필터 값 목록** (대소문자 구분 없음, 잘못된 값 입력 시 Bad Request)
+        
+        - **habitats**:
+            - mudflat (갯벌)
+            - farmland (경작지/들판)
+            - forest (산림/계곡)
+            - marine (해양)
+            - residential (거주지역)
+            - plains_forest (평지숲)
+            - river_lake (하천/호수)
+            - artificial (인공시설)
+            - cave (동굴)
+            - wetland (습지)
+            - others (기타)
+        
+        - **sizeCategories**:
+            - xsmall, small, medium, large
+        
+        - **seasons**:
+            - spring, summer, autumn, winter
+        """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "도감 조회/검색 응답",
+                            content = @Content(schema = @Schema(implementation = BirdSearchResponse.class))
+            ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청 (파라미터 값 오타일 가능성 큼)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
     )
     public ResponseEntity<BirdSearchResponse> getBirds(
             @Parameter(description = "페이지 번호 (1부터 시작)", example = "1") @RequestParam(required = false) Integer page,
@@ -85,15 +103,24 @@ public class BirdController {
             @Parameter(description = "검색 키워드 (한글 이름)") @RequestParam(required = false) String q,
             @Parameter(description = "서식지 필터") @RequestParam(required = false) List<String> habitats,
             @Parameter(description = "크기 필터") @RequestParam(required = false) List<String> sizeCategories,
-            @Parameter(description = "계절 필터") @RequestParam(required = false) List<String> seasons
+            @Parameter(description = "계절 필터") @RequestParam(required = false) List<String> seasons,
+            @Parameter(description = "정렬 기준") @RequestParam(required = false, defaultValue = "id") String sort,
+            @Parameter(description = "정렬 방향") @RequestParam(required = false, defaultValue = "asc") String sortDir
     ) {
-        BirdSearchCommand birdSearchCommand = new BirdSearchCommand();
-        birdSearchCommand.setPage(page);
-        birdSearchCommand.setSize(size);
-        birdSearchCommand.setQ(q);
-        birdSearchCommand.setHabitats(habitats);
-        birdSearchCommand.setSizeCategories(sizeCategories);
-        birdSearchCommand.setSeasons(seasons);
+        BirdSearchCommand birdSearchCommand = new BirdSearchCommand(
+                page,
+                size,
+                q,
+                habitats,
+                sizeCategories,
+                seasons,
+                sort,
+                sortDir
+        );
+
+        if (!birdSearchCommand.hasValidPagination()) {
+            throw new BadRequestException("page와 size 값이 유효하지 않아요.");
+        }
 
         BirdSearchResponse response = birdQueryService.getBirdSearchResponse(birdSearchCommand);
         return ResponseEntity.ok(response);

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/BirdQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/BirdQueryService.java
@@ -10,17 +10,19 @@ import org.devkor.apu.saerok_server.domain.dex.bird.application.dto.BirdSearchCo
 import org.devkor.apu.saerok_server.domain.dex.bird.domain.enums.HabitatType;
 import org.devkor.apu.saerok_server.domain.dex.bird.domain.mapper.BirdMapper;
 import org.devkor.apu.saerok_server.domain.dex.bird.api.dto.response.BirdSizeCategoryRulesResponse;
-import org.devkor.apu.saerok_server.domain.dex.bird.domain.entity.Bird;
 import org.devkor.apu.saerok_server.domain.dex.bird.domain.repository.BirdRepository;
 import org.devkor.apu.saerok_server.domain.dex.bird.domain.service.SizeCategoryService;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.dto.BirdSearchDto;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.dto.CmRangeDto;
+import org.devkor.apu.saerok_server.domain.dex.bird.query.enums.BirdSearchSortDirType;
+import org.devkor.apu.saerok_server.domain.dex.bird.query.enums.BirdSearchSortType;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.enums.SeasonType;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.mapper.SizeCategoryRulesMapper;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.view.BirdProfileView;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.mapper.BirdProfileViewMapper;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.repository.BirdProfileViewRepository;
 import org.devkor.apu.saerok_server.global.config.SizeCategoryRulesConfig;
+import org.devkor.apu.saerok_server.global.exception.BadRequestException;
 import org.devkor.apu.saerok_server.global.exception.NotFoundException;
 import org.devkor.apu.saerok_server.global.util.EnumParser;
 import org.springframework.stereotype.Service;
@@ -29,7 +31,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -93,38 +94,59 @@ public class BirdQueryService {
     }
 
     public BirdSearchResponse getBirdSearchResponse(BirdSearchCommand birdSearchCommand) {
-        if (!birdSearchCommand.hasValidPagination()) {
-            throw new IllegalStateException("not valid pagination");
+        List<HabitatType> habitats;
+        List<SeasonType> seasons;
+        List<CmRangeDto> cmRanges;
+        BirdSearchSortType sortBy;
+        BirdSearchSortDirType sortDir;
+
+        try {
+            habitats = EnumParser.parseStringList(HabitatType.class, birdSearchCommand.habitats());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("서식지 필터 값이 유효하지 않아요.");
         }
 
         try {
-            List<HabitatType> habitats = EnumParser.parseStringList(HabitatType.class, birdSearchCommand.getHabitats());
-            List<SeasonType> seasons = EnumParser.parseStringList(SeasonType.class, birdSearchCommand.getSeasons());
-            List<CmRangeDto> cmRanges = new ArrayList<>();
+            seasons = EnumParser.parseStringList(SeasonType.class, birdSearchCommand.seasons());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("계절 필터 값이 유효하지 않아요.");
+        }
+
+        try {
+            cmRanges = new ArrayList<>();
             for (String sizeCategory : birdSearchCommand.getSizeCategories()) {
                 cmRanges.add(new CmRangeDto(
                         sizeCategoryService.getMinCmFromCategory(sizeCategory),
                         sizeCategoryService.getMaxCmFromCategory(sizeCategory)
                 ));
             }
-
-            BirdSearchDto birdSearchDto = new BirdSearchDto(
-                    birdSearchCommand.getPage(),
-                    birdSearchCommand.getSize(),
-                    birdSearchCommand.getQ(),
-                    habitats,
-                    cmRanges,
-                    seasons
-            );
-
-            List<BirdSearchResponse.BirdSearchItem> birds = birdMapper.toDtoList(birdRepository.search(birdSearchDto));
-            BirdSearchResponse response = new BirdSearchResponse();
-            response.setBirds(birds);
-            return response;
         }
         catch (IllegalArgumentException e) {
-            throw new IllegalStateException("not valid string");
+            throw new BadRequestException("크기 필터 값이 유효하지 않아요.");
         }
+
+        try {
+            sortBy = EnumParser.fromString(BirdSearchSortType.class, birdSearchCommand.sort());
+            sortDir = EnumParser.fromString(BirdSearchSortDirType.class, birdSearchCommand.sortDir());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("정렬 파라미터 값이 유효하지 않아요.");
+        }
+
+        BirdSearchDto birdSearchDto = new BirdSearchDto(
+                birdSearchCommand.page(),
+                birdSearchCommand.size(),
+                birdSearchCommand.q(),
+                habitats,
+                cmRanges,
+                seasons,
+                sortBy,
+                sortDir
+        );
+
+        List<BirdSearchResponse.BirdSearchItem> birds = birdMapper.toDtoList(birdRepository.search(birdSearchDto));
+        BirdSearchResponse response = new BirdSearchResponse();
+        response.setBirds(birds);
+        return response;
     }
 
     public BirdSizeCategoryRulesResponse getSizeCategoryRulesResponse() {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/dto/BirdSearchCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/application/dto/BirdSearchCommand.java
@@ -1,19 +1,17 @@
 package org.devkor.apu.saerok_server.domain.dex.bird.application.dto;
 
-import lombok.Data;
-
 import java.util.List;
 
-@Data
-public class BirdSearchCommand {
-
-    private Integer page;
-    private Integer size;
-    private String q;
-    private List<String> habitats;
-    private List<String> sizeCategories;
-    private List<String> seasons;
-
+public record BirdSearchCommand (
+        Integer page,
+        Integer size,
+        String q,
+        List<String> habitats,
+        List<String> sizeCategories,
+        List<String> seasons,
+        String sort,
+        String sortDir
+){
     /**
      * size와 page 중 한쪽만 null일 수 없고,
      * size >= 1, page >= 1

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/domain/repository/BirdRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/domain/repository/BirdRepository.java
@@ -101,7 +101,10 @@ public class BirdRepository {
         }
 
         /* 정렬 */
-        sql.append(" ORDER BY b.korean_name ");
+        sql.append(" ORDER BY b.")
+            .append(dto.sortBy().getColumn())
+            .append(" ")
+            .append(dto.sortDir().name());
 
         Query query = em.createNativeQuery(sql.toString(), Bird.class);
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/dto/BirdSearchDto.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/dto/BirdSearchDto.java
@@ -2,6 +2,8 @@ package org.devkor.apu.saerok_server.domain.dex.bird.query.dto;
 
 import lombok.Data;
 import org.devkor.apu.saerok_server.domain.dex.bird.domain.enums.HabitatType;
+import org.devkor.apu.saerok_server.domain.dex.bird.query.enums.BirdSearchSortDirType;
+import org.devkor.apu.saerok_server.domain.dex.bird.query.enums.BirdSearchSortType;
 import org.devkor.apu.saerok_server.domain.dex.bird.query.enums.SeasonType;
 
 import java.util.List;
@@ -12,6 +14,8 @@ public record BirdSearchDto(
         String q,
         List<HabitatType> habitats,
         List<CmRangeDto> cmRanges,
-        List<SeasonType> seasons
+        List<SeasonType> seasons,
+        BirdSearchSortType sortBy,
+        BirdSearchSortDirType sortDir
 ) {
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/enums/BirdSearchSortDirType.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/enums/BirdSearchSortDirType.java
@@ -1,0 +1,6 @@
+package org.devkor.apu.saerok_server.domain.dex.bird.query.enums;
+
+public enum BirdSearchSortDirType {
+    ASC,
+    DESC,
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/enums/BirdSearchSortType.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/enums/BirdSearchSortType.java
@@ -1,0 +1,21 @@
+package org.devkor.apu.saerok_server.domain.dex.bird.query.enums;
+
+/**
+ * 도감 검색 시 정렬 기준.
+ * column 필드는 DB의 실제 필드 이름에 의존하므로 주의! 추후 리팩토링 가능 지점.
+ */
+public enum BirdSearchSortType {
+    ID("id"),
+    KOREAN_NAME("korean_name"),
+    BODY_LENGTH("body_length_cm");
+
+    private final String column;
+
+    BirdSearchSortType(String column) {
+        this.column = column;
+    }
+
+    public String getColumn() {
+        return column;
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/global/exception/BadRequestException.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package org.devkor.apu.saerok_server.global.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package org.devkor.apu.saerok_server.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -13,6 +15,14 @@ public class GlobalExceptionHandler {
         ErrorResponse error = new ErrorResponse(500, ex.getMessage());
         return ResponseEntity.
                 internalServerError().
+                body(error);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(BadRequestException ex) {
+        ErrorResponse error = new ErrorResponse(400, ex.getMessage());
+        return ResponseEntity.
+                badRequest().
                 body(error);
     }
     

--- a/src/main/java/org/devkor/apu/saerok_server/global/util/EnumParser.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/util/EnumParser.java
@@ -6,6 +6,10 @@ import java.util.List;
 public class EnumParser {
 
     public static <T extends Enum<T>> T fromString(Class<T> enumType, String value) {
+        if (value == null) {
+            return null;
+        }
+
         return Enum.valueOf(enumType, value.toUpperCase());
     }
 


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
도감 검색/조회 API에 정렬 기능을 추가했습니다.
이용 가능한 정렬 기준: id, 한국 이름, 몸 크기
각각 오름차순/내림차순 가능

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.