### PR TITLE
feat(coll): 컬렉션 삭제 API 구현

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -345,15 +345,14 @@ public class CollectionController {
 
     @DeleteMapping("/{collectionId}")
     @Operation(
-            summary = "[미구현] 컬렉션 삭제",
+            summary = "컬렉션 삭제",
             description = """
-            컬렉션 및 연관된 이미지 레코드를 모두 삭제합니다.
-            (이미지 파일 자체 삭제 여부는 정책에 따라 구현)
+            해당 컬렉션 및 컬렉션에 딸린 이미지를 모두 삭제합니다.
             """,
             responses = {
-                    @ApiResponse(responseCode = "204", description = "삭제 성공"),
-                    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "컬렉션 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "204", description = "컬렉션 삭제 성공"),
+                    @ApiResponse(responseCode = "403", description = "해당 컬렉션에 대한 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "요청한 컬렉션이 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -361,6 +360,7 @@ public class CollectionController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long collectionId
     ) {
-        // TODO: 미구현
+        Long userId = userPrincipal.getId();
+        collectionCommandService.deleteCollection(collectionWebMapper.toDeleteCollectionCommand(userId, collectionId));
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
@@ -3,20 +3,28 @@ package org.devkor.apu.saerok_server.domain.collection.application;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionCommand;
+import org.devkor.apu.saerok_server.domain.collection.application.dto.DeleteCollectionCommand;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionImage;
+import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionImageRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.Bird;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.repository.BirdRepository;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
 import org.devkor.apu.saerok_server.global.exception.BadRequestException;
+import org.devkor.apu.saerok_server.global.exception.ForbiddenException;
+import org.devkor.apu.saerok_server.global.exception.NotFoundException;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
 
-import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @Transactional
@@ -26,6 +34,11 @@ public class CollectionCommandService {
     private final CollectionRepository collectionRepository;
     private final UserRepository userRepository;
     private final BirdRepository birdRepository;
+    private final S3Client s3Client;
+    private final CollectionImageRepository collectionImageRepository;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
 
     public Long createCollection(CreateCollectionCommand command) {
         User user = userRepository.findById(command.userId()).orElseThrow(() -> new BadRequestException("유효하지 않은 사용자 id예요"));
@@ -74,5 +87,31 @@ public class CollectionCommandService {
                 .build();
 
         return collectionRepository.save(collection);
+    }
+
+    public void deleteCollection(DeleteCollectionCommand command) {
+        User user = userRepository.findById(command.userId()).orElseThrow(() -> new BadRequestException("유효하지 않은 사용자 id예요"));
+        UserBirdCollection collection = collectionRepository.findById(command.collectionId()).orElseThrow(() -> new NotFoundException("해당 id의 컬렉션이 존재하지 않아요"));
+        if (!command.userId().equals(collection.getUser().getId())) {
+            throw new ForbiddenException("해당 컬렉션에 대한 권한이 없어요");
+        }
+
+        List<String> objectKeys = collectionImageRepository.findObjectKeysByCollectionId(command.collectionId());
+
+        if (!objectKeys.isEmpty()) {
+            List<ObjectIdentifier> objectsToDelete = objectKeys.stream()
+                    .map(key -> ObjectIdentifier.builder().key(key).build())
+                    .toList();
+            DeleteObjectsRequest deleteRequest = DeleteObjectsRequest.builder()
+                    .bucket(bucket)
+                    .delete(Delete.builder().objects(objectsToDelete).build())
+                    .build();
+            s3Client.deleteObjects(deleteRequest);
+
+            // TODO: 추후 운영/고도화 단계에서 S3 이미지 삭제 실패 감지 및 후처리
+        }
+
+        collectionImageRepository.removeByCollectionId(command.collectionId());
+        collectionRepository.remove(collection);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/DeleteCollectionCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/DeleteCollectionCommand.java
@@ -1,0 +1,7 @@
+package org.devkor.apu.saerok_server.domain.collection.application.dto;
+
+public record DeleteCollectionCommand(
+        Long userId,
+        Long collectionId
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionImageRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionImageRepository.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionImage;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -20,5 +21,17 @@ public class CollectionImageRepository {
     public Long save(UserBirdCollectionImage image) {
         em.persist(image);
         return image.getId();
+    }
+
+    public List<String> findObjectKeysByCollectionId(Long collectionId) {
+        return em.createQuery("SELECT i.objectKey FROM UserBirdCollectionImage i WHERE i.collection.id = :collectionId", String.class)
+                .setParameter("collectionId", collectionId)
+                .getResultList();
+    }
+
+    public void removeByCollectionId(Long collectionId) {
+        em.createQuery("DELETE FROM UserBirdCollectionImage i WHERE i.collection.id = :collectionId")
+                .setParameter("collectionId", collectionId)
+                .executeUpdate();
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionRepository.java
@@ -21,4 +21,8 @@ public class CollectionRepository {
         em.persist(collection);
         return collection.getId();
     }
+
+    public void remove(UserBirdCollection collection) {
+        em.remove(collection);
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -5,7 +5,7 @@ import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateColl
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionResponse;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionCommand;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionImageCommand;
-import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
+import org.devkor.apu.saerok_server.domain.collection.application.dto.DeleteCollectionCommand;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
@@ -22,4 +22,8 @@ public interface CollectionWebMapper {
     CreateCollectionResponse toCreateCollectionResponse(Long collectionId);
 
     CreateCollectionImageCommand toCreateCollectionImageCommand(CreateCollectionImageRequest request);
+
+    @Mapping(target = "userId", source = "userId")
+    @Mapping(target = "collectionId", source = "collectionId")
+    DeleteCollectionCommand toDeleteCollectionCommand(Long userId, Long collectionId);
 }


### PR DESCRIPTION
## 📝 요약(Summary)

컬렉션 삭제 API를 구현했습니다.
S3의 이미지를 먼저 삭제한 뒤, DB 데이터를 삭제합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.