### PR TITLE
chore(coll): 컬렉션 등록 API에서 tempBirdName 받지 않게 수정

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -38,7 +38,6 @@ public class CollectionController {
         새 컬렉션(관찰 기록)을 생성합니다. 이 단계에서는 **이미지를 제외한 메타데이터만 전송**합니다.
 
         ⚠️ 유효성 제약:
-        - birdId와 tempBirdName은 반드시 하나만 있어야 함
         - note는 50자 이하
 
         📌 이 API를 먼저 호출하여 컬렉션을 생성한 후,
@@ -63,8 +62,7 @@ public class CollectionController {
                     description = """
                             컬렉션 생성 요청 DTO.
                             
-                            - `birdId`와 `tempBirdName` 둘 중 하나는 null이고, 다른 하나는 null이 아니어야 합니다. 위반 시 Bad Request
-                            <br> ex) 도감에 등록된 새라면 `birdId = 42, tempBirdName = null`. 그렇지 않으면 `birdId = null, tempBirdName = "이상한 새"`
+                            - birdId가 null이면 종 미식별을 의미합니다.`
                             """,
                     required = true,
                     content = @Content(

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/CreateCollectionRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/CreateCollectionRequest.java
@@ -14,9 +14,6 @@ public class CreateCollectionRequest {
     @Schema(description = "관찰한 새의 ID", example = "null", nullable = true)
     private Long birdId;
 
-    @Schema(description = "사용자가 직접 입력한 새 이름 (종을 특정하지 못한 경우)", example = "이상한 새", nullable = true)
-    private String tempBirdName;
-
     @Schema(description = "관찰한 날짜 (yyyy-MM-dd 형식)", example = "2024-05-15", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDate discoveredDate;
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
@@ -42,22 +42,13 @@ public class CollectionCommandService {
 
     public Long createCollection(CreateCollectionCommand command) {
         User user = userRepository.findById(command.userId()).orElseThrow(() -> new BadRequestException("유효하지 않은 사용자 id예요"));
-        if (command.birdId() == null && (command.tempBirdName() == null || command.tempBirdName().isEmpty())) {
-            throw new BadRequestException("조류 정보를 포함해주세요");
-        }
-        if (command.birdId() != null && (command.tempBirdName() != null && !command.tempBirdName().isEmpty())) {
-            throw new BadRequestException("조류 id와 사용자가 직접 입력한 새 이름을 둘 다 등록할 수는 없어요");
-        }
 
         Bird bird;
-        String tempBirdName;
 
         if (command.birdId() != null) {
             bird = birdRepository.findById(command.birdId()).orElseThrow(() -> new BadRequestException("유효하지 않은 조류 id예요"));
-            tempBirdName = null;
         } else {
             bird = null;
-            tempBirdName = command.tempBirdName();
         }
 
         if (command.discoveredDate() == null) {
@@ -79,7 +70,7 @@ public class CollectionCommandService {
         UserBirdCollection collection = UserBirdCollection.builder()
                 .user(user)
                 .bird(bird)
-                .tempBirdName(tempBirdName)
+                .tempBirdName(null) // 일단 tempBirdName 미사용하기로 하여 null로 설정
                 .discoveredDate(command.discoveredDate())
                 .location(location)
                 .locationAlias(command.locationAlias())

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/CreateCollectionCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/CreateCollectionCommand.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 public record CreateCollectionCommand (
         Long userId,
         Long birdId,
-        String tempBirdName,
         LocalDate discoveredDate,
         Double latitude,
         Double longitude,


### PR DESCRIPTION


## 📝 요약(Summary)

컬렉션 등록 API 요청 시 tempBirdName을 받지 않도록 수정했습니다. (회의로 결정된 사항 반영)
* 내부적으로 tempBirdName을 항상 null로 설정하게 했습니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.