### PR TITLE
feat(coll): 컬렉션 수정 API 구현

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -9,10 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CollectionImagePresignRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionImageRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionRequest;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionImageResponse;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionResponse;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionEditDataResponse;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.PresignResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.request.UpdateCollectionRequest;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.*;
 import org.devkor.apu.saerok_server.domain.collection.application.CollectionCommandService;
 import org.devkor.apu.saerok_server.domain.collection.application.CollectionImageCommandService;
 import org.devkor.apu.saerok_server.domain.collection.application.CollectionQueryService;
@@ -312,32 +310,33 @@ public class CollectionController {
 
 
 
-    @PutMapping("/{collectionId}/edit")
+    @PatchMapping("/{collectionId}/edit")
     @Operation(
-            summary = "[미구현] 컬렉션 메타데이터 수정",
+            summary = "컬렉션 메타데이터 수정",
             description = """
-            기존에 생성한 컬렉션의 메타데이터를 수정합니다.  
-            조류 정보, 장소 정보, 관찰 일시, 한 줄 평, 핀 여부 등을 변경할 수 있습니다.
+            기존에 생성한 컬렉션의 메타데이터를 수정합니다.
+            수정하고 싶은 필드만 요청 json에 담아서 보낼 수 있습니다.
+            
+            birdId를 수정하려면 반드시 isBirdIdUpdated = true도 포함해야 합니다.
             
             ⚠️ 수정 대상: 이미지 제외한 컬렉션의 모든 메타데이터
             
-            ✅ 사용 예시:
-            - `birdId`와 `tempBirdName`은 생성 API와 동일하게 **둘 중 하나만 존재해야 함**
+            ✅ 유효성 조건:
             - `note`는 50자 이하
             """,
             responses = {
-                    @ApiResponse(responseCode = "200", description = "수정 성공"),
+                    @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = UpdateCollectionResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "컬렉션 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "404", description = "요청한 자원이 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    public void updateCollection(
+    public UpdateCollectionResponse updateCollection(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @PathVariable Long collectionId
-            // @RequestBody UpdateCollectionRequest request
+            @PathVariable Long collectionId,
+            @RequestBody UpdateCollectionRequest request
     ) {
-        // TODO: 미구현
+        return collectionCommandService.updateCollection(collectionWebMapper.toUpdateCollectionCommand(request, userPrincipal.getId(), collectionId));
     }
 
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -11,9 +11,11 @@ import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateColl
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionImageResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionEditDataResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.PresignResponse;
 import org.devkor.apu.saerok_server.domain.collection.application.CollectionCommandService;
 import org.devkor.apu.saerok_server.domain.collection.application.CollectionImageCommandService;
+import org.devkor.apu.saerok_server.domain.collection.application.CollectionQueryService;
 import org.devkor.apu.saerok_server.domain.collection.mapper.CollectionWebMapper;
 import org.devkor.apu.saerok_server.global.exception.ErrorResponse;
 import org.devkor.apu.saerok_server.global.security.UserPrincipal;
@@ -30,6 +32,7 @@ public class CollectionController {
     private final CollectionWebMapper collectionWebMapper;
     private final CollectionCommandService collectionCommandService;
     private final CollectionImageCommandService collectionImageCommandService;
+    private final CollectionQueryService collectionQueryService;
 
     @PostMapping
     @Operation(
@@ -292,24 +295,21 @@ public class CollectionController {
 
     @GetMapping("/{collectionId}/edit")
     @Operation(
-            summary = "[미구현] 컬렉션 수정 폼 데이터 조회",
+            summary = "컬렉션 수정용 상세 조회",
             description = """
-            컬렉션 수정 화면 진입 시 필요한 정보를 조회합니다.  
-            기존에 저장된 메타데이터(조류 정보, 관찰 일시 및 위치, 한 줄 평, 핀 여부 등)를 반환합니다.
-            
-            ✅ 이 API는 수정 폼에 데이터를 채워넣기 위한 용도로만 사용됩니다.
+            컬렉션 수정 시 필요한 정보를 조회합니다.
             """,
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = GetCollectionEditDataResponse.class))),
                     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "컬렉션 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    public void getCollectionEditForm(
+    public GetCollectionEditDataResponse getCollectionEditData(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long collectionId
     ) {
-        // TODO: 미구현
+        return collectionQueryService.getCollectionEditDataResponse(collectionWebMapper.toGetCollectionDataCommand(userPrincipal.getId(), collectionId));
     }
 
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -293,8 +293,8 @@ public class CollectionController {
     @Operation(
             summary = "컬렉션 수정용 상세 조회",
             description = """
-            컬렉션 수정 시 필요한 정보를 조회합니다.
-            """,
+                    컬렉션 수정 시 필요한 정보를 조회합니다.
+                    """,
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = GetCollectionEditDataResponse.class))),
                     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -307,7 +307,6 @@ public class CollectionController {
     ) {
         return collectionQueryService.getCollectionEditDataResponse(collectionWebMapper.toGetCollectionDataCommand(userPrincipal.getId(), collectionId));
     }
-
 
 
     @PatchMapping("/{collectionId}/edit")
@@ -359,5 +358,29 @@ public class CollectionController {
     ) {
         Long userId = userPrincipal.getId();
         collectionCommandService.deleteCollection(collectionWebMapper.toDeleteCollectionCommand(userId, collectionId));
+    }
+
+    @DeleteMapping("/{collectionId}/images/{imageId}")
+    @Operation(
+            summary = "컬렉션 이미지 삭제",
+            description = """
+                    지정한 컬렉션 이미지를 삭제합니다.
+                    * imageId는 컬렉션 수정용 상세 조회 API를 통해 얻을 수 있습니다.
+                    * 컬렉션 이미지를 교체하고 싶으면, "컬렉션 이미지 삭제 -> 컬렉션 이미지 Presigned URL 발급 -> 해당 URL로 이미지 PUT 업로드 -> 컬렉션 이미지 메타데이터 등록"을 하면 됩니다.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "컬렉션 이미지 삭제 성공"),
+                    @ApiResponse(responseCode = "403", description = "해당 컬렉션에 대한 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "요청한 자원이 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteCollectionImage(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long collectionId,
+            @PathVariable Long imageId
+    ) {
+        Long userId = userPrincipal.getId();
+        collectionImageCommandService.deleteCollectionImage(userId, collectionId, imageId);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/UpdateCollectionRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/UpdateCollectionRequest.java
@@ -1,0 +1,34 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Schema(description = "컬렉션(관찰 기록) 수정 요청 DTO")
+@Data
+@NoArgsConstructor
+public class UpdateCollectionRequest {
+
+    @Schema(description = "birdId를 수정할 것인지 여부", example = "true")
+    private Boolean isBirdIdUpdated;
+
+    @Schema(description = "관찰한 새의 ID", example = "null", nullable = true)
+    private Long birdId;
+
+    @Schema(description = "관찰한 날짜 (yyyy-MM-dd 형식)", example = "2024-05-15", requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDate discoveredDate;
+
+    @Schema(description = "관찰 지점의 경도", example = "126.5583", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Double longitude;
+
+    @Schema(description = "관찰 지점의 위도", example = "33.2395", requiredMode = Schema.RequiredMode.REQUIRED)
+    private Double latitude;
+
+    @Schema(description = "관찰 지점에 대한 사용자 지정 장소 별칭", example = "서귀포 갯벌", nullable = true)
+    private String locationAlias;
+
+    @Schema(description = "관찰 기록에 대한 간단한 메모", example = "까치가 엄청 날아다녔다", nullable = true)
+    private String note;
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
@@ -1,0 +1,51 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
+import org.locationtech.jts.geom.Point;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Schema(description = "컬렉션 수정용 상세 조회 응답 DTO")
+public class GetCollectionEditDataResponse {
+
+    @Schema(description = "관찰한 새의 ID", example = "101")
+    private Long birdId;
+
+    @Schema(description = "관찰 날짜", example = "2024-05-21")
+    private LocalDate discoveredDate;
+
+    @Schema(description = "관찰 위치 경도", example = "127.123456")
+    private double longitude;
+
+    @Schema(description = "관찰 위치 위도", example = "37.987654")
+    private double latitude;
+
+    @Schema(description = "관찰 위치 별칭", example = "서울숲")
+    private String locationAlias;
+
+    @Schema(description = "한 줄 평", example = "까치가 무리를 지어 날아다님")
+    private String note;
+
+    @Schema(description = "컬렉션 공개 범위 (공개/비공개)")
+    private AccessLevelType accessLevel;
+
+    @Schema(description = "컬렉션에 첨부된 이미지 정보 목록")
+    private List<ImageInfo> images;
+
+    @Data
+    @AllArgsConstructor
+    @Schema(description = "이미지 정보")
+    public static class ImageInfo {
+
+        @Schema(description = "이미지 ID", example = "300")
+        private Long id;
+
+        @Schema(description = "이미지 URL", example = "https://cdn.example.com/images/300.jpg")
+        private String url;
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
@@ -1,0 +1,16 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record UpdateCollectionResponse (
+        Long collectionId,
+        Long birdId,
+        LocalDate discoveredDate,
+        Double longitude,
+        Double latitude,
+        String locationAlias,
+        String note,
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
@@ -2,12 +2,14 @@ package org.devkor.apu.saerok_server.domain.collection.application;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.UpdateCollectionResponse;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionCommand;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.DeleteCollectionCommand;
+import org.devkor.apu.saerok_server.domain.collection.application.dto.UpdateCollectionCommand;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
-import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionImage;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionImageRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
+import org.devkor.apu.saerok_server.domain.collection.mapper.CollectionWebMapper;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.Bird;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.repository.BirdRepository;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
@@ -15,6 +17,7 @@ import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
 import org.devkor.apu.saerok_server.global.exception.BadRequestException;
 import org.devkor.apu.saerok_server.global.exception.ForbiddenException;
 import org.devkor.apu.saerok_server.global.exception.NotFoundException;
+import org.devkor.apu.saerok_server.global.util.CloudFrontUrlService;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -36,17 +39,19 @@ public class CollectionCommandService {
     private final BirdRepository birdRepository;
     private final S3Client s3Client;
     private final CollectionImageRepository collectionImageRepository;
+    private final CloudFrontUrlService cloudFrontUrlService;
+    private final CollectionWebMapper collectionWebMapper;
 
     @Value("${aws.s3.bucket}")
     private String bucket;
 
     public Long createCollection(CreateCollectionCommand command) {
-        User user = userRepository.findById(command.userId()).orElseThrow(() -> new BadRequestException("유효하지 않은 사용자 id예요"));
+        User user = userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
 
         Bird bird;
 
         if (command.birdId() != null) {
-            bird = birdRepository.findById(command.birdId()).orElseThrow(() -> new BadRequestException("유효하지 않은 조류 id예요"));
+            bird = birdRepository.findById(command.birdId()).orElseThrow(() -> new NotFoundException("존재하지 않는 조류 id예요"));
         } else {
             bird = null;
         }
@@ -81,7 +86,7 @@ public class CollectionCommandService {
     }
 
     public void deleteCollection(DeleteCollectionCommand command) {
-        User user = userRepository.findById(command.userId()).orElseThrow(() -> new BadRequestException("유효하지 않은 사용자 id예요"));
+        User user = userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
         UserBirdCollection collection = collectionRepository.findById(command.collectionId()).orElseThrow(() -> new NotFoundException("해당 id의 컬렉션이 존재하지 않아요"));
         if (!command.userId().equals(collection.getUser().getId())) {
             throw new ForbiddenException("해당 컬렉션에 대한 권한이 없어요");
@@ -104,5 +109,50 @@ public class CollectionCommandService {
 
         collectionImageRepository.removeByCollectionId(command.collectionId());
         collectionRepository.remove(collection);
+    }
+
+    public UpdateCollectionResponse updateCollection(UpdateCollectionCommand command) {
+        User user = userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
+        UserBirdCollection collection = collectionRepository.findById(command.collectionId()).orElseThrow(() -> new NotFoundException("해당 id의 컬렉션이 존재하지 않아요"));
+        if (!command.userId().equals(collection.getUser().getId())) {
+            throw new ForbiddenException("해당 컬렉션에 대한 권한이 없어요");
+        }
+
+        System.out.println(command.isBirdIdUpdated());
+        if (command.isBirdIdUpdated() != null && command.isBirdIdUpdated()) {
+            if (command.birdId() != null) {
+                Bird bird = birdRepository.findById(command.birdId()).orElseThrow(() -> new NotFoundException("존재하지 않는 조류 id예요"));
+                collection.setBird(bird);
+            } else {
+                collection.setBird(null);
+            }
+        }
+
+        if (command.discoveredDate() != null) collection.setDiscoveredDate(command.discoveredDate());
+
+        if ((command.latitude() == null) ^ (command.longitude() == null)) {
+            throw new BadRequestException("위도와 경도 둘 중 하나만 수정할 수는 없어요");
+        } else if (command.latitude() != null) {
+            GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+            Coordinate coordinate = new Coordinate(command.longitude(), command.latitude());
+            Point location = geometryFactory.createPoint(coordinate);
+            collection.setLocation(location);
+        }
+
+        if (command.locationAlias() != null) collection.setLocationAlias(command.locationAlias());
+
+        if (command.note() != null) {
+            if (command.note().length() > UserBirdCollection.NOTE_MAX_LENGTH) {
+                throw new BadRequestException("한 줄 평 길이는 " + UserBirdCollection.NOTE_MAX_LENGTH + "자 이하여야 해요");
+            }
+
+            collection.setNote(command.note());
+        }
+
+        List<String> urls = collectionImageRepository.findObjectKeysByCollectionId(command.collectionId()).stream()
+                .map(cloudFrontUrlService::toImageUrl)
+                .toList();
+
+        return collectionWebMapper.toUpdateCollectionResponse(collection, urls);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
@@ -1,9 +1,51 @@
 package org.devkor.apu.saerok_server.domain.collection.application;
 
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionEditDataResponse;
+import org.devkor.apu.saerok_server.domain.collection.application.dto.GetCollectionEditDataCommand;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionImage;
+import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionImageRepository;
+import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
+import org.devkor.apu.saerok_server.domain.collection.mapper.CollectionWebMapper;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.devkor.apu.saerok_server.global.exception.BadRequestException;
+import org.devkor.apu.saerok_server.global.exception.ForbiddenException;
+import org.devkor.apu.saerok_server.global.exception.NotFoundException;
+import org.devkor.apu.saerok_server.global.util.CloudFrontUrlService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class CollectionQueryService {
+
+    private final CollectionRepository collectionRepository;
+    private final CollectionImageRepository collectionImageRepository;
+    private final UserRepository userRepository;
+    private final CollectionWebMapper collectionWebMapper;
+    private final CloudFrontUrlService cloudFrontUrlService;
+
+    public GetCollectionEditDataResponse getCollectionEditDataResponse(GetCollectionEditDataCommand command) {
+        User user = userRepository.findById(command.userId()).orElseThrow(() -> new BadRequestException("유효하지 않은 사용자 id예요"));
+        UserBirdCollection collection = collectionRepository.findById(command.collectionId()).orElseThrow(() -> new NotFoundException("해당 id의 컬렉션이 존재하지 않아요"));
+        if (!command.userId().equals(collection.getUser().getId())) {
+            throw new ForbiddenException("해당 컬렉션에 대한 권한이 없어요");
+        }
+
+        GetCollectionEditDataResponse response = collectionWebMapper.toGetCollectionEditDataResponse(collection);
+        List<UserBirdCollectionImage> images = collectionImageRepository.findByCollectionId(command.collectionId());
+        List<GetCollectionEditDataResponse.ImageInfo> imageInfos = images.stream()
+                .map(image -> new GetCollectionEditDataResponse.ImageInfo(
+                            image.getId(),
+                            cloudFrontUrlService.toImageUrl(image.getObjectKey())
+                    ))
+                .toList();
+        response.setImages(imageInfos);
+        return response;
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/GetCollectionEditDataCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/GetCollectionEditDataCommand.java
@@ -1,0 +1,7 @@
+package org.devkor.apu.saerok_server.domain.collection.application.dto;
+
+public record GetCollectionEditDataCommand(
+        Long userId,
+        Long collectionId
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/UpdateCollectionCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/UpdateCollectionCommand.java
@@ -1,0 +1,16 @@
+package org.devkor.apu.saerok_server.domain.collection.application.dto;
+
+import java.time.LocalDate;
+
+public record UpdateCollectionCommand (
+        Long userId,
+        Long collectionId,
+        Boolean isBirdIdUpdated,
+        Long birdId,
+        LocalDate discoveredDate,
+        Double latitude,
+        Double longitude,
+        String locationAlias,
+        String note
+){
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/entity/UserBirdCollection.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/entity/UserBirdCollection.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.Bird;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.global.entity.Auditable;
@@ -30,21 +31,26 @@ public class UserBirdCollection extends Auditable {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bird_id", nullable = true)
+    @Setter
     private Bird bird;
 
     @Column(name = "temp_bird_name")
     private String tempBirdName;
 
     @Column(name = "discovered_date", nullable = false)
+    @Setter
     private LocalDate discoveredDate;
 
     @Column(name = "location", columnDefinition = "geometry(Point,4326)", nullable = false)
+    @Setter
     private Point location;
 
     @Column(name = "location_alias")
+    @Setter
     private String locationAlias;
 
     @Column(name = "note")
+    @Setter
     private String note;
 
     @Column(name = "is_pinned")
@@ -53,6 +59,7 @@ public class UserBirdCollection extends Auditable {
     @Enumerated(EnumType.STRING)
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "access_level", nullable = false, columnDefinition = "access_level_enum")
+    @Setter
     private AccessLevelType accessLevel;
 
     @Builder

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/entity/UserBirdCollection.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/entity/UserBirdCollection.java
@@ -72,4 +72,12 @@ public class UserBirdCollection extends Auditable {
         this.isPinned = isPinned;
         this.accessLevel = accessLevel == null ? AccessLevelType.PUBLIC : accessLevel;
     }
+
+    public double getLongitude() {
+        return location.getX();
+    }
+
+    public double getLatitude() {
+        return location.getY();
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionImageRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionImageRepository.java
@@ -29,6 +29,12 @@ public class CollectionImageRepository {
                 .getResultList();
     }
 
+    public List<UserBirdCollectionImage> findByCollectionId(Long collectionId) {
+        return em.createQuery("SELECT i FROM UserBirdCollectionImage i WHERE i.collection.id = :collectionId", UserBirdCollectionImage.class)
+                .setParameter("collectionId", collectionId)
+                .getResultList();
+    }
+
     public void removeByCollectionId(Long collectionId) {
         em.createQuery("DELETE FROM UserBirdCollectionImage i WHERE i.collection.id = :collectionId")
                 .setParameter("collectionId", collectionId)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionImageRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionImageRepository.java
@@ -35,6 +35,10 @@ public class CollectionImageRepository {
                 .getResultList();
     }
 
+    public void remove(UserBirdCollectionImage image) {
+        em.remove(image);
+    }
+
     public void removeByCollectionId(Long collectionId) {
         em.createQuery("DELETE FROM UserBirdCollectionImage i WHERE i.collection.id = :collectionId")
                 .setParameter("collectionId", collectionId)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -2,17 +2,15 @@ package org.devkor.apu.saerok_server.domain.collection.mapper;
 
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionImageRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionRequest;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.request.UpdateCollectionRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionEditDataResponse;
-import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionCommand;
-import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionImageCommand;
-import org.devkor.apu.saerok_server.domain.collection.application.dto.DeleteCollectionCommand;
-import org.devkor.apu.saerok_server.domain.collection.application.dto.GetCollectionEditDataCommand;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.UpdateCollectionResponse;
+import org.devkor.apu.saerok_server.domain.collection.application.dto.*;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
-import org.mapstruct.Named;
 
 import java.util.List;
 
@@ -40,4 +38,11 @@ public interface CollectionWebMapper {
     @Mapping(target = "birdId", source = "bird.id")
     @Mapping(target = "images", ignore = true)
     GetCollectionEditDataResponse toGetCollectionEditDataResponse(UserBirdCollection collection);
+
+    @Mapping(target = "userId", source = "userId")
+    UpdateCollectionCommand toUpdateCollectionCommand(UpdateCollectionRequest request, Long userId, Long collectionId);
+
+    @Mapping(target = "birdId", source = "collection.bird.id")
+    @Mapping(target = "imageUrls", source = "imageUrls")
+    UpdateCollectionResponse toUpdateCollectionResponse(UserBirdCollection collection, List<String> imageUrls);
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -3,12 +3,18 @@ package org.devkor.apu.saerok_server.domain.collection.mapper;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionImageRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionEditDataResponse;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionCommand;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionImageCommand;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.DeleteCollectionCommand;
+import org.devkor.apu.saerok_server.domain.collection.application.dto.GetCollectionEditDataCommand;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
+import org.mapstruct.Named;
+
+import java.util.List;
 
 @Mapper(
         componentModel = MappingConstants.ComponentModel.SPRING
@@ -26,4 +32,12 @@ public interface CollectionWebMapper {
     @Mapping(target = "userId", source = "userId")
     @Mapping(target = "collectionId", source = "collectionId")
     DeleteCollectionCommand toDeleteCollectionCommand(Long userId, Long collectionId);
+
+    @Mapping(target = "userId", source = "userId")
+    @Mapping(target = "collectionId", source = "collectionId")
+    GetCollectionEditDataCommand toGetCollectionDataCommand(Long userId, Long collectionId);
+
+    @Mapping(target = "birdId", source = "bird.id")
+    @Mapping(target = "images", ignore = true)
+    GetCollectionEditDataResponse toGetCollectionEditDataResponse(UserBirdCollection collection);
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/exception/GlobalExceptionHandler.java
@@ -41,4 +41,12 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.FORBIDDEN)
                 .body(error);
     }
+
+    @ExceptionHandler(S3DeleteException.class)
+    public ResponseEntity<ErrorResponse> handleS3DeleteException(S3DeleteException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(error);
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/exception/S3DeleteException.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/exception/S3DeleteException.java
@@ -1,0 +1,7 @@
+package org.devkor.apu.saerok_server.global.exception;
+
+public class S3DeleteException extends RuntimeException {
+    public S3DeleteException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

컬렉션 수정 API를 구현했습니다.
세부적으로는 3가지 API를 추가했습니다.
- 컬렉션 수정용 상세 조회
- 컬렉션 메타데이터 수정 (이미지 제외한 정보들 수정)
- 컬렉션 이미지 삭제 (컬렉션 이미지를 수정하고 싶을 경우, 기존의 컬렉션 이미지 등록하는 API와 함께 사용)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.