### PR TITLE
chore(dex): 도감 중복 아종 데이터 제거

### DIFF
--- a/src/main/resources/db/migration/V10__delete_bird_duplicate_data.sql
+++ b/src/main/resources/db/migration/V10__delete_bird_duplicate_data.sql
@@ -1,0 +1,27 @@
+-- 도감 데이터 중 한국어 이름이 중복인 데이터 제거
+-- 기존 17쌍 중복이었고, 각각 학명 기준으로 아종(subspecies) 데이터를 삭제하여 중복 제거함
+-- ex) 2개의 매 데이터가 있을 때(Falco peregrinus vs.  Falco peregrinus japonensis), 아종 데이터(Falco peregrinus japonensis) 삭제
+
+-- 1. bird_image에서 연관 데이터 삭제 (S3에서 실제 이미지 삭제 작업 진행하였음)
+DELETE FROM bird_image
+WHERE bird_id IN (
+                  597, 557, 523, 445, 586, 570, 593, 521, 423, 506, 441, 443, 444, 518, 425, 553, 517
+    );
+
+-- 2. bird_habitat에서 연관 데이터 삭제
+DELETE FROM bird_habitat
+WHERE bird_id IN (
+                  597, 557, 523, 445, 586, 570, 593, 521, 423, 506, 441, 443, 444, 518, 425, 553, 517
+    );
+
+-- 3. bird_residency에서 연관 데이터 삭제
+DELETE FROM bird_residency
+WHERE bird_id IN (
+                  597, 557, 523, 445, 586, 570, 593, 521, 423, 506, 441, 443, 444, 518, 425, 553, 517
+    );
+
+-- 4. bird 테이블에서 삭제
+DELETE FROM bird
+WHERE id IN (
+             597, 557, 523, 445, 586, 570, 593, 521, 423, 506, 441, 443, 444, 518, 425, 553, 517
+    );


### PR DESCRIPTION
## 📝 요약(Summary)

도감 중복 아종 데이터를 제거했습니다. (이전에 회의해서 결정한 바에 따름)
기존 17쌍이 중복되던 것에서 하나씩 아종 데이터를 제거했고, 이제 도감 조류 개수는 585개 (602 - 17) 입니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.