### PR TITLE
chore(infra): ELB 헬스 체크 API 구현

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/system/controller/SystemController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/system/controller/SystemController.java
@@ -18,56 +18,18 @@ import java.util.Optional;
 @Hidden
 @Tag(name = "System API", description = "시스템 상태 점검 관련 API")
 @RestController
-@RequestMapping("${api_prefix}/system")
+@RequestMapping
 public class SystemController {
 
-    private final UserRepository userRepository;
-    @Value("${spring.profiles.active}")
-    private String activeProfile;
-
-    public SystemController(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
-
-    @GetMapping("/ping")
+    @GetMapping("/health")
     @Operation(
-            summary = "시스템 핑",
-            description = "시스템이 살아있는지 확인합니다.",
+            summary = "시스템 헬스 체크",
+            description = "시스템이 살아있는지 확인합니다. (ELB 헬스 체크 대응)",
             responses = {
                     @ApiResponse(responseCode = "200", description = "정상 응답")
             }
     )
     public String ping() {
-        return "pong from saerok-server";
-    }
-
-    @GetMapping("/profile")
-    @Operation(
-            summary = "서버 프로파일 확인",
-            description = "서버가 로컬 서버 설정인지, 개발 서버 설정인지, 운영 서버 설정인지 확인합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "정상 응답")
-            }
-    )
-    public String getActiveProfile() {
-        return activeProfile;
-    }
-
-    @GetMapping("/me")
-    @Operation(
-            summary = "인증된 유저 정보 확인",
-            description = "인증된 유저 정보를 확인합니다. (실제로 쓸 API는 아니고, 이런 식으로 인증된 사용자 정보를 꺼내쓸 수 있다는 예시)",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "정상 응답")
-            }
-    )
-    public String getMe(
-            @AuthenticationPrincipal UserPrincipal userPrincipal
-            ) {
-        Long id = userPrincipal.getId();
-
-        Optional<User> user = userRepository.findById(id);
-        return user.map(value -> "현재 로그인된 사용자의 id: " + value.getId() + ", 닉네임: " + value.getNickname()).orElse("유효하지 않은 사용자 id");
-
+        return "I am healthy";
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

ELB 대응을 위한 헬스 체크 API를 구현했습니다.
단순히 현재 서버가 살아 있는지를 확인하기 위한 용도입니다

## 💬 공유사항

도메인 주소 및 HTTPS 적용에 앞서 ELB(Elastic Load Balancer)를 세팅 중입니다!
앞으로 사용자 요청은 제일 먼저 이 ELB가 받아들인 뒤, 뒤쪽의 웹 서버(EC2)에게 넘겨주게 되는데요. ELB는 정기적으로 EC2 인스턴스가 살아있는지 확인을 하기 위한 요청을 보냅니다. 그래서 200번대 응답이 오면 잘 살아있는 것으로 인지를 합니다. 이것을 헬스 체크라고 하구요. `GET /health`로 헬스 체크 확인을 하도록 세팅을 해뒀고, 이에 대응하기 위한 작업입니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.