### PR TITLE
chore(infra): Swagger 서버 url 환경별 분기 지원 및 OpenApiConfig 추가

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/global/config/OpenApiConfig.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package org.devkor.apu.saerok_server.global.config;
+
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${swagger.server-url}")
+    private String swaggerServerUrl;
+
+    @Bean
+    public OpenApiCustomizer openApiCustomizer() {
+        return openApi -> openApi.setServers(
+                List.of(new Server().url(swaggerServerUrl))
+        );
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,9 @@ spring:
 server:
   port: 8080
 
+swagger:
+  server-url: https://dev-api.saerok.app
+
 aws:
   credentials:
     access-key: ${IAM_ACCESS_KEY}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,9 @@ server:
 
 logging.level.org.hibernate.sql: debug
 
+swagger:
+  server-url: http://localhost:8080
+
 aws:
   credentials:
     access-key: ${IAM_ACCESS_KEY}


### PR DESCRIPTION
## 📝 요약(Summary)

환경별로(로컬, 개발 API 서버) Swagger UI에서 API 테스트할 때 사용할 서버 url이 달라지도록 설정했습니다.
로컬(local): `http://localhost:8080`
개발(dev): `https://dev-api.saerok.app`

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.