### PR TITLE
docs(): swagger에 인증토큰이 필요한 api 명시를 위한 작업

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CollectionImagePresignRequest;
@@ -42,6 +43,7 @@ public class CollectionController {
     @PostMapping
     @Operation(
             summary = "컬렉션 등록 (종추)",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = """
         새 컬렉션(관찰 기록)을 생성합니다. 이 단계에서는 **이미지를 제외한 메타데이터만 전송**합니다.
 
@@ -107,6 +109,7 @@ public class CollectionController {
     @PostMapping("/{collectionId}/images/presign")
     @Operation(
             summary = "컬렉션 이미지 Presigned URL 발급",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = """
         특정 컬렉션에 이미지 파일을 업로드할 수 있도록 **S3 Presigned URL을 발급**합니다.
 
@@ -177,6 +180,7 @@ public class CollectionController {
     @PostMapping("/{collectionId}/images")
     @Operation(
             summary = "컬렉션 이미지 메타데이터 등록",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = """
         클라이언트가 S3에 이미지 업로드를 완료한 후,
         해당 이미지의 **메타데이터(objectKey, contentType)** 를 서버에 등록합니다.
@@ -254,6 +258,7 @@ public class CollectionController {
     @GetMapping("/me")
     @Operation(
             summary = "내 컬렉션 목록 조회",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = """
             ✅ 응답 예시 필드  
             - collectionId  
@@ -277,6 +282,7 @@ public class CollectionController {
     @GetMapping("/{collectionId}/edit")
     @Operation(
             summary = "컬렉션 수정용 상세 조회",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = """
                     컬렉션 수정 시 필요한 정보를 조회합니다.
                     """,
@@ -297,6 +303,7 @@ public class CollectionController {
     @PatchMapping("/{collectionId}/edit")
     @Operation(
             summary = "컬렉션 메타데이터 수정",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = """
             기존에 생성한 컬렉션의 메타데이터를 수정합니다.
             수정하고 싶은 필드만 요청 json에 담아서 보낼 수 있습니다.
@@ -327,6 +334,7 @@ public class CollectionController {
     @DeleteMapping("/{collectionId}")
     @Operation(
             summary = "컬렉션 삭제",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = """
             해당 컬렉션 및 컬렉션에 딸린 이미지를 모두 삭제합니다.
             """,
@@ -348,6 +356,7 @@ public class CollectionController {
     @DeleteMapping("/{collectionId}/images/{imageId}")
     @Operation(
             summary = "컬렉션 이미지 삭제",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = """
                     지정한 컬렉션 이미지를 삭제합니다.
                     * imageId는 컬렉션 수정용 상세 조회 API를 통해 얻을 수 있습니다.

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bookmark/api/BookmarkController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bookmark/api/BookmarkController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.devkor.apu.saerok_server.domain.dex.bookmark.api.dto.response.BookmarkResponse;
@@ -14,7 +15,7 @@ import org.devkor.apu.saerok_server.domain.dex.bookmark.application.BookmarkServ
 import org.devkor.apu.saerok_server.global.exception.ErrorResponse;
 import org.devkor.apu.saerok_server.global.security.UserPrincipal;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,6 +31,7 @@ public class BookmarkController {
     @GetMapping("/")
     @Operation(
             summary = "내 북마크 목록 조회",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = "사용자가 북마크한 조류 목록을 조회합니다. 북마크 엔티티의 정보만 포함합니다.",
             responses = {
                 @ApiResponse(
@@ -44,8 +46,8 @@ public class BookmarkController {
                 )
             }
     )
-    public ResponseEntity<List<BookmarkResponse>> getBookmarks(Authentication authentication) {
-        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+    public ResponseEntity<List<BookmarkResponse>> getBookmarks(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         Long userId = userPrincipal.getId();
         
         List<BookmarkResponse> bookmarks = bookmarkService.getBookmarksResponse(userId);
@@ -55,6 +57,7 @@ public class BookmarkController {
     @GetMapping("/items")
     @Operation(
             summary = "북마크한 조류 상세 정보 조회",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = "사용자가 북마크한 조류들의 상세 정보를 조회합니다.",
             responses = {
                 @ApiResponse(
@@ -69,8 +72,8 @@ public class BookmarkController {
                 )
             }
     )
-    public ResponseEntity<List<BookmarkedBirdDetailResponse>> getBookmarkedBirdDetails(Authentication authentication) {
-        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+    public ResponseEntity<List<BookmarkedBirdDetailResponse>> getBookmarkedBirdDetails(
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         Long userId = userPrincipal.getId();
         
         List<BookmarkedBirdDetailResponse> birdDetails = bookmarkService.getBookmarkedBirdDetailsResponse(userId);
@@ -80,6 +83,7 @@ public class BookmarkController {
     @PostMapping("/{birdId}/toggle")
     @Operation(
             summary = "조류 북마크 토글",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = "특정 조류에 대한 북마크를 추가하거나 제거합니다.",
             responses = {
                 @ApiResponse(
@@ -101,8 +105,7 @@ public class BookmarkController {
     )
     public ResponseEntity<BookmarkToggleResponse> toggleBookmark(
             @PathVariable Long birdId,
-            Authentication authentication) {
-        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         Long userId = userPrincipal.getId();
         
         BookmarkToggleResponse response = bookmarkService.toggleBookmarkResponse(userId, birdId);
@@ -112,6 +115,7 @@ public class BookmarkController {
     @GetMapping("/{birdId}/status")
     @Operation(
             summary = "조류 북마크 상태 확인",
+            security = @SecurityRequirement(name = "bearerAuth"),
             description = "특정 조류에 대한 북마크 상태를 확인합니다.",
             responses = {
                 @ApiResponse(
@@ -128,8 +132,7 @@ public class BookmarkController {
     )
     public ResponseEntity<BookmarkStatusResponse> getBookmarkStatus(
             @PathVariable Long birdId,
-            Authentication authentication) {
-        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
         Long userId = userPrincipal.getId();
         
         BookmarkStatusResponse statusResponse = bookmarkService.getBookmarkStatusResponse(userId, birdId);

--- a/src/main/java/org/devkor/apu/saerok_server/global/config/OpenApiConfig.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/config/OpenApiConfig.java
@@ -1,5 +1,9 @@
 package org.devkor.apu.saerok_server.global.config;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,5 +23,20 @@ public class OpenApiConfig {
         return openApi -> openApi.setServers(
                 List.of(new Server().url(swaggerServerUrl))
         );
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Saerok API")
+                        .description("새록 API 문서")
+                        .version("v1.0"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

swagger에 어떤 api가 인증토큰이 필요한 api인지 명시하기 위한 작업을 해봤습니다.

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->

## 💬 공유사항

@soonduck-dreams 
bearer이 가장 보편적이고 카카오/애플 로그인 역시 이 방식으로 하면 된다고 하여 일단 bearer 방식으로 해놨습니다.
추후에 다른 인증방식 사용 시 bearerAuth 부분만 수정하면 될 듯 합니다.

태그는... 뭘 해야할지 몰라서 그냥 docs로 했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.