### PR TITLE
feat(user): 회원 정보 API 구현, 애플 소셜 로그인 응답에 signupStatus 추가

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/AuthController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/AuthController.java
@@ -28,9 +28,14 @@ public class AuthController {
     @Operation(
             summary = "Apple 소셜 로그인",
             description = """
-                    애플 로그인 인가 코드를 이용해 회원가입 및 로그인을 처리하고, 서버에게 신원을 인증하기 위한 액세스 토큰을 발급받습니다.
+                    애플 로그인 인가 코드를 이용해 회원가입 및 로그인을 처리합니다. 
                     
-                    액세스 토큰의 유효 기간은 7일입니다.
+                    응답에는 accessToken, signupStatus가 들어 있습니다.<br>
+                    accessToken으로 서버에게 사용자 신원을 인증할 수 있습니다. (유효 기간: 7일)<br>
+                    signupStatus는 회원가입 상태를 나타냅니다. 사용자가 회원가입 절차를 마쳤는지 알 수 있습니다.<br>
+                    signupStatus가 가질 수 있는 값:
+                     - PROFILE_REQUIRED: 필수 회원 정보 입력이 필요함
+                     - COMPLETED: 회원가입 절차를 마쳤음
                     
                     """,
             responses = {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/AuthController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/AuthController.java
@@ -1,4 +1,4 @@
-package org.devkor.apu.saerok_server.domain.user.auth.api;
+package org.devkor.apu.saerok_server.domain.auth.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -7,9 +7,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import lombok.RequiredArgsConstructor;
-import org.devkor.apu.saerok_server.domain.user.auth.api.dto.request.AppleLoginRequest;
-import org.devkor.apu.saerok_server.domain.user.auth.api.dto.response.JwtResponse;
-import org.devkor.apu.saerok_server.domain.user.auth.application.AppleAuthService;
+import org.devkor.apu.saerok_server.domain.auth.api.dto.request.AppleLoginRequest;
+import org.devkor.apu.saerok_server.domain.auth.api.dto.response.JwtResponse;
+import org.devkor.apu.saerok_server.domain.auth.application.AppleAuthService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/LocalAuthController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/LocalAuthController.java
@@ -1,10 +1,10 @@
-package org.devkor.apu.saerok_server.domain.user.auth.api;
+package org.devkor.apu.saerok_server.domain.auth.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import lombok.RequiredArgsConstructor;
-import org.devkor.apu.saerok_server.domain.user.auth.api.dto.response.JwtResponse;
+import org.devkor.apu.saerok_server.domain.auth.api.dto.response.JwtResponse;
 import org.devkor.apu.saerok_server.domain.user.core.entity.UserRoleType;
 import org.devkor.apu.saerok_server.global.security.jwt.JwtProvider;
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/LocalAuthController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/LocalAuthController.java
@@ -4,15 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import lombok.RequiredArgsConstructor;
-import org.devkor.apu.saerok_server.domain.auth.api.dto.response.JwtResponse;
-import org.devkor.apu.saerok_server.domain.user.core.entity.UserRoleType;
-import org.devkor.apu.saerok_server.global.security.jwt.JwtProvider;
+import org.devkor.apu.saerok_server.domain.auth.api.dto.response.LocalJwtResponse;
+import org.devkor.apu.saerok_server.domain.auth.application.LocalAuthService;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Profile("local")
 @RestController
@@ -21,7 +18,7 @@ import java.util.List;
 @Tag(name = "로컬 테스트", description = "로컬 개발환경 전용 API")
 public class LocalAuthController {
 
-    private final JwtProvider jwtProvider;
+    private final LocalAuthService localAuthService;
 
     @Operation(
             summary = "더미 유저 JWT 발급",
@@ -29,11 +26,7 @@ public class LocalAuthController {
     )
     @GetMapping("/dummy-user-token")
     @PermitAll
-    public JwtResponse issueLocalDummyUserToken() {
-        String token = jwtProvider.createAccessToken(
-                99999L,
-                List.of(UserRoleType.USER.name())
-        );
-        return new JwtResponse(token);
+    public LocalJwtResponse issueLocalDummyUserToken() {
+        return localAuthService.issueLocalDummyUserToken();
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/request/AppleLoginRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/request/AppleLoginRequest.java
@@ -1,4 +1,4 @@
-package org.devkor.apu.saerok_server.domain.user.auth.api.dto.request;
+package org.devkor.apu.saerok_server.domain.auth.api.dto.request;
 
 public record AppleLoginRequest (
         String authorizationCode

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/response/JwtResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/response/JwtResponse.java
@@ -1,0 +1,6 @@
+package org.devkor.apu.saerok_server.domain.auth.api.dto.response;
+
+public record JwtResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/response/LocalJwtResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/response/LocalJwtResponse.java
@@ -3,12 +3,12 @@ package org.devkor.apu.saerok_server.domain.auth.api.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "JWT 토큰 및 회원가입 상태 응답")
-public record JwtResponse(
+public record LocalJwtResponse(
 
         @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
         String accessToken,
 
-        @Schema(description = "회원가입 상태", example = "COMPLETED")
+        @Schema(description = "회원가입 진행 상태", example = "COMPLETED")
         String signupStatus
 ) {
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/AppleAuthService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/AppleAuthService.java
@@ -1,15 +1,15 @@
-package org.devkor.apu.saerok_server.domain.user.auth.application;
+package org.devkor.apu.saerok_server.domain.auth.application;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.devkor.apu.saerok_server.domain.user.auth.api.dto.response.JwtResponse;
-import org.devkor.apu.saerok_server.domain.user.auth.core.entity.SocialAuth;
-import org.devkor.apu.saerok_server.domain.user.auth.core.entity.SocialProviderType;
-import org.devkor.apu.saerok_server.domain.user.auth.core.repository.SocialAuthRepository;
-import org.devkor.apu.saerok_server.domain.user.auth.infra.AppleApiClient;
+import org.devkor.apu.saerok_server.domain.auth.api.dto.response.JwtResponse;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialAuth;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
+import org.devkor.apu.saerok_server.domain.auth.core.repository.SocialAuthRepository;
+import org.devkor.apu.saerok_server.domain.auth.infra.AppleApiClient;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.domain.user.core.entity.UserRole;
 import org.devkor.apu.saerok_server.domain.user.core.entity.UserRoleType;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/AppleAuthService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/AppleAuthService.java
@@ -56,12 +56,13 @@ public class AppleAuthService {
 
         socialAuth.setLastLoginAt(OffsetDateTime.now());
 
-        List<String> roles = userRoleRepository.findByUser(socialAuth.getUser()).stream()
+        User user = socialAuth.getUser();
+        List<String> roles = userRoleRepository.findByUser(user).stream()
                 .map(ur -> ur.getRole().name())
                 .toList();
 
-        String accessToken = jwtProvider.createAccessToken(socialAuth.getUser().getId(), roles);
-        return new JwtResponse(accessToken);
+        String accessToken = jwtProvider.createAccessToken(user.getId(), roles);
+        return new JwtResponse(accessToken, user.getSignupStatus().name());
 
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/LocalAuthService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/LocalAuthService.java
@@ -1,0 +1,37 @@
+package org.devkor.apu.saerok_server.domain.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.auth.api.dto.response.LocalJwtResponse;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRoleRepository;
+import org.devkor.apu.saerok_server.global.security.jwt.JwtProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LocalAuthService {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final UserRoleRepository userRoleRepository;
+
+    public LocalJwtResponse issueLocalDummyUserToken() {
+
+        User user = userRepository.findById(99999L).orElseThrow(() -> new IllegalStateException("로컬 더미 유저가 존재하지 않습니다"));
+        List<String> roles = userRoleRepository.findByUser(user).stream()
+                .map(ur -> ur.getRole().name())
+                .toList();
+
+        String token = jwtProvider.createAccessToken(
+                user.getId(),
+                roles
+        );
+
+        return new LocalJwtResponse(token, user.getSignupStatus().name());
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/entity/SocialAuth.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/entity/SocialAuth.java
@@ -1,4 +1,4 @@
-package org.devkor.apu.saerok_server.domain.user.auth.core.entity;
+package org.devkor.apu.saerok_server.domain.auth.core.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/entity/SocialProviderType.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/entity/SocialProviderType.java
@@ -1,0 +1,6 @@
+package org.devkor.apu.saerok_server.domain.auth.core.entity;
+
+public enum SocialProviderType {
+    APPLE,
+    KAKAO
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/entity/UserAuth.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/entity/UserAuth.java
@@ -1,4 +1,4 @@
-package org.devkor.apu.saerok_server.domain.user.auth.core.entity;
+package org.devkor.apu.saerok_server.domain.auth.core.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/SocialAuthRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/SocialAuthRepository.java
@@ -1,9 +1,9 @@
-package org.devkor.apu.saerok_server.domain.user.auth.core.repository;
+package org.devkor.apu.saerok_server.domain.auth.core.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import org.devkor.apu.saerok_server.domain.user.auth.core.entity.SocialAuth;
-import org.devkor.apu.saerok_server.domain.user.auth.core.entity.SocialProviderType;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialAuth;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/AppleApiClient.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/AppleApiClient.java
@@ -1,11 +1,11 @@
-package org.devkor.apu.saerok_server.domain.user.auth.infra;
+package org.devkor.apu.saerok_server.domain.auth.infra;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.devkor.apu.saerok_server.domain.user.auth.infra.dto.AppleErrorResponse;
-import org.devkor.apu.saerok_server.domain.user.auth.infra.dto.AppleTokenResponse;
+import org.devkor.apu.saerok_server.domain.auth.infra.dto.AppleErrorResponse;
+import org.devkor.apu.saerok_server.domain.auth.infra.dto.AppleTokenResponse;
 import org.devkor.apu.saerok_server.global.config.AppleProperties;
 import org.devkor.apu.saerok_server.global.exception.AppleAuthException;
 import org.springframework.http.HttpStatusCode;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/dto/AppleErrorResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/dto/AppleErrorResponse.java
@@ -1,4 +1,4 @@
-package org.devkor.apu.saerok_server.domain.user.auth.infra.dto;
+package org.devkor.apu.saerok_server.domain.auth.infra.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/dto/AppleTokenResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/dto/AppleTokenResponse.java
@@ -1,4 +1,4 @@
-package org.devkor.apu.saerok_server.domain.user.auth.infra.dto;
+package org.devkor.apu.saerok_server.domain.auth.infra.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/api/UserController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/api/UserController.java
@@ -1,0 +1,122 @@
+package org.devkor.apu.saerok_server.domain.user.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.PermitAll;
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.user.api.dto.request.UpdateUserProfileRequest;
+import org.devkor.apu.saerok_server.domain.user.api.dto.response.UpdateUserProfileResponse;
+import org.devkor.apu.saerok_server.domain.user.api.response.CheckNicknameResponse;
+import org.devkor.apu.saerok_server.domain.user.api.response.GetMyUserProfileResponse;
+import org.devkor.apu.saerok_server.domain.user.application.UserCommandService;
+import org.devkor.apu.saerok_server.domain.user.application.UserQueryService;
+import org.devkor.apu.saerok_server.domain.user.mapper.UserWebMapper;
+import org.devkor.apu.saerok_server.global.security.UserPrincipal;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User API", description = "회원 정보 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("${api_prefix}/user/")
+public class UserController {
+
+    private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
+    private final UserWebMapper userWebMapper;
+
+    @GetMapping("/me")
+    @PreAuthorize("hasRole('USER')")
+    @Operation(
+            summary = "나의 회원 정보 조회",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            description = """
+            나의 회원 정보를 조회합니다.
+            """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공",
+                            content = @Content(schema = @Schema(implementation = GetMyUserProfileResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "사용자 인증 실패",
+                            content = @Content
+                    ),
+            }
+    )
+    public GetMyUserProfileResponse getMyUserProfile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        return userQueryService.getMyUserProfile(userPrincipal.getId());
+    }
+
+    @PatchMapping("/me")
+    @PreAuthorize("hasRole('USER')")
+    @Operation(
+            summary = "나의 회원 정보 수정",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            description = """
+            회원 정보를 수정합니다. 수정할 항목만 골라 보낼 수 있습니다.
+
+            수정 가능한 항목
+              - nickname (닉네임 정책 미준수 또는 다른 사용자와 중복 시 400 Bad Request)
+            
+            닉네임 정책
+              - 닉네임은 0자일 수 없음
+              - 닉네임의 앞뒤로 공백이 있을 수 없음
+            """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원 정보 수정 성공",
+                            content = @Content(schema = @Schema(implementation = UpdateUserProfileResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "회원 정보 수정 실패",
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "사용자 인증 실패",
+                            content = @Content
+                    ),
+            }
+    )
+    public UpdateUserProfileResponse updateUserProfile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestBody UpdateUserProfileRequest request
+    ) {
+        return userCommandService.updateUserProfile(
+                userWebMapper.toUpdateUserProfileCommand(request, userPrincipal.getId())
+        );
+    }
+
+    @GetMapping("/check-nickname")
+    @PermitAll
+    @Operation(
+            summary = "닉네임 중복 확인",
+            description = """
+            해당 닉네임이 다른 사용자에 의해 사용되고 있는지 조회합니다.
+            """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공",
+                            content = @Content(schema = @Schema(implementation = CheckNicknameResponse.class))
+                    ),
+            }
+    )
+    public CheckNicknameResponse checkNickname(
+            @RequestParam String nickname
+    ) {
+        return userQueryService.checkNickname(nickname);
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/api/dto/request/UpdateUserProfileRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/api/dto/request/UpdateUserProfileRequest.java
@@ -1,0 +1,14 @@
+package org.devkor.apu.saerok_server.domain.user.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "사용자 정보 수정 요청 DTO")
+@Data
+@NoArgsConstructor
+public class UpdateUserProfileRequest {
+
+    @Schema(description = "사용자 닉네임", example = "새록이")
+    private String nickname;
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/api/dto/response/UpdateUserProfileResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/api/dto/response/UpdateUserProfileResponse.java
@@ -1,0 +1,9 @@
+package org.devkor.apu.saerok_server.domain.user.api.dto.response;
+
+import lombok.Data;
+
+public record UpdateUserProfileResponse(
+        String nickname,
+        String email
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/api/response/CheckNicknameResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/api/response/CheckNicknameResponse.java
@@ -1,0 +1,6 @@
+package org.devkor.apu.saerok_server.domain.user.api.response;
+
+public record CheckNicknameResponse(
+        boolean isUsedByOtherUser
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/api/response/GetMyUserProfileResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/api/response/GetMyUserProfileResponse.java
@@ -1,0 +1,7 @@
+package org.devkor.apu.saerok_server.domain.user.api.response;
+
+public record GetMyUserProfileResponse(
+        String nickname,
+        String email
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserCommandService.java
@@ -1,0 +1,42 @@
+package org.devkor.apu.saerok_server.domain.user.application;
+
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.user.api.dto.response.UpdateUserProfileResponse;
+import org.devkor.apu.saerok_server.domain.user.application.dto.UpdateUserProfileCommand;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.devkor.apu.saerok_server.domain.user.core.service.UserProfileUpdateService;
+import org.devkor.apu.saerok_server.domain.user.core.service.UserSignupStatusService;
+import org.devkor.apu.saerok_server.global.exception.BadRequestException;
+import org.devkor.apu.saerok_server.global.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserCommandService {
+
+    private final UserRepository userRepository;
+    private final UserProfileUpdateService userProfileUpdateService;
+    private final UserSignupStatusService userSignupStatusService;
+
+    public UpdateUserProfileResponse updateUserProfile(UpdateUserProfileCommand command) {
+
+        User user = userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
+
+        try {
+            if (command.nickname() != null) userProfileUpdateService.changeNickname(user, command.nickname());
+
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("사용자 정보 수정이 거부되었습니다: " + e.getMessage());
+        }
+
+        userSignupStatusService.tryCompleteSignup(user);
+
+        return new UpdateUserProfileResponse(
+                user.getNickname(),
+                user.getEmail()
+        );
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserQueryService.java
@@ -1,0 +1,34 @@
+package org.devkor.apu.saerok_server.domain.user.application;
+
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.user.api.response.CheckNicknameResponse;
+import org.devkor.apu.saerok_server.domain.user.api.response.GetMyUserProfileResponse;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.devkor.apu.saerok_server.global.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserQueryService {
+
+    private final UserRepository userRepository;
+
+    public GetMyUserProfileResponse getMyUserProfile(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException("해당 id의 사용자가 존재하지 않아요"));
+
+        return new GetMyUserProfileResponse(
+                user.getNickname(),
+                user.getEmail()
+        );
+    }
+
+    public CheckNicknameResponse checkNickname(String nickname) {
+
+        return new CheckNicknameResponse(
+                userRepository.findByNickname(nickname).isPresent()
+        );
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/application/dto/UpdateUserProfileCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/application/dto/UpdateUserProfileCommand.java
@@ -1,0 +1,7 @@
+package org.devkor.apu.saerok_server.domain.user.application.dto;
+
+public record UpdateUserProfileCommand(
+        Long userId,
+        String nickname
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/auth/api/dto/response/JwtResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/auth/api/dto/response/JwtResponse.java
@@ -1,6 +1,0 @@
-package org.devkor.apu.saerok_server.domain.user.auth.api.dto.response;
-
-public record JwtResponse(
-        String accessToken
-) {
-}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/auth/core/entity/SocialProviderType.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/auth/core/entity/SocialProviderType.java
@@ -1,6 +1,0 @@
-package org.devkor.apu.saerok_server.domain.user.auth.core.entity;
-
-public enum SocialProviderType {
-    APPLE,
-    KAKAO
-}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/User.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/User.java
@@ -2,6 +2,7 @@ package org.devkor.apu.saerok_server.domain.user.core.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 import org.devkor.apu.saerok_server.global.entity.SoftDeletableAuditable;
 
 import java.time.LocalDate;
@@ -16,6 +17,7 @@ public class User extends SoftDeletableAuditable {
     private Long id;
 
     @Column(name = "nickname")
+    @Setter
     private String nickname;
 
     @Column(name = "birth_date")
@@ -33,6 +35,7 @@ public class User extends SoftDeletableAuditable {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "signup_status")
+    @Setter
     private SignupStatusType signupStatus;
 
     public static User createUser(String email) {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/repository/UserRepository.java
@@ -24,4 +24,11 @@ public class UserRepository {
         em.persist(user);
         return user;
     }
+
+    public Optional<User> findByNickname(String nickname) {
+        return em.createQuery("SELECT u FROM User u WHERE u.nickname = :nickname AND u.deletedAt IS NULL", User.class)
+                .setParameter("nickname", nickname)
+                .getResultStream()
+                .findFirst();
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/service/UserProfilePolicy.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/service/UserProfilePolicy.java
@@ -1,0 +1,22 @@
+package org.devkor.apu.saerok_server.domain.user.core.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserProfilePolicy {
+
+    public boolean isNicknameValid(String nickname) {
+
+        if (nickname == null || nickname.isEmpty()) return false; // 닉네임은 null이거나 0자일 수 없음
+        if (!nickname.equals(nickname.trim())) return false; // 닉네임 앞뒤로 공백이 있을 수 없음
+
+        return true;
+    }
+
+    public boolean isEmailValid(String email) {
+        if (email == null) return false;
+
+        String emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
+        return email.matches(emailRegex);
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/service/UserProfileUpdateService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/service/UserProfileUpdateService.java
@@ -1,0 +1,33 @@
+package org.devkor.apu.saerok_server.domain.user.core.service;
+
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자 프로필 수정을 전담하는 Domain Service.
+ * 각 프로필 항목의 규칙에 따라 수정을 허용하거나 반려합니다. (ex: 닉네임은 0글자일 수 없음)
+ */
+@Service
+@RequiredArgsConstructor
+public class UserProfileUpdateService {
+
+    private final UserProfilePolicy userProfilePolicy;
+    private final UserRepository userRepository;
+
+    public void changeNickname(User user, String nickname) {
+
+        if (user.getNickname().equals(nickname)) return;
+
+        if (!userProfilePolicy.isNicknameValid(nickname)) {
+            throw new IllegalArgumentException("해당 닉네임은 정책상 사용할 수 없습니다.");
+        }
+
+        if (userRepository.findByNickname(nickname).isPresent()) {
+            throw new IllegalArgumentException("해당 닉네임은 다른 사용자가 사용 중입니다.");
+        }
+
+        user.setNickname(nickname);
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/service/UserSignupStatusService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/service/UserSignupStatusService.java
@@ -1,0 +1,27 @@
+package org.devkor.apu.saerok_server.domain.user.core.service;
+
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.user.core.entity.SignupStatusType;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자 데이터를 조사하고, 규칙을 만족할 경우 signup_status를 업데이트할 책임을 지는 도메인 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserSignupStatusService {
+
+    private final UserProfilePolicy userProfilePolicy;
+
+    public void tryCompleteSignup(User user) {
+
+        if (user.getSignupStatus() == SignupStatusType.COMPLETED) return;
+
+        if (userProfilePolicy.isNicknameValid(user.getNickname())
+                && userProfilePolicy.isEmailValid(user.getEmail())
+        ) {
+            user.setSignupStatus(SignupStatusType.COMPLETED);
+        }
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/mapper/UserWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/mapper/UserWebMapper.java
@@ -1,0 +1,14 @@
+package org.devkor.apu.saerok_server.domain.user.mapper;
+
+import org.devkor.apu.saerok_server.domain.user.api.dto.request.UpdateUserProfileRequest;
+import org.devkor.apu.saerok_server.domain.user.application.dto.UpdateUserProfileCommand;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+@Mapper(
+        componentModel = MappingConstants.ComponentModel.SPRING
+)
+public interface UserWebMapper {
+
+    UpdateUserProfileCommand toUpdateUserProfileCommand(UpdateUserProfileRequest request, Long userId);
+}

--- a/src/main/resources/db/migration/V17__user_nickname_is_unique.sql
+++ b/src/main/resources/db/migration/V17__user_nickname_is_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD CONSTRAINT uq_users_nickname UNIQUE (nickname);

--- a/src/test/java/org/devkor/apu/saerok_server/domain/user/core/service/UserProfileUpdateServiceTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/user/core/service/UserProfileUpdateServiceTest.java
@@ -1,0 +1,84 @@
+package org.devkor.apu.saerok_server.domain.user.core.service;
+
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserProfileUpdateServiceTest {
+
+    UserProfileUpdateService userProfileUpdateService;
+
+    @Mock
+    UserProfilePolicy userProfilePolicy;
+
+    @Mock
+    UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userProfileUpdateService = new UserProfileUpdateService(userProfilePolicy, userRepository);
+    }
+
+    @Test
+    @DisplayName("닉네임이 정책에 부합하고 중복이 없으면 변경 성공")
+    void changeNickname_success() {
+        // given
+        User user = new User();
+        user.setNickname("old");
+        String newNick = "new";
+
+        given(userProfilePolicy.isNicknameValid(newNick)).willReturn(true);
+        given(userRepository.findByNickname(newNick)).willReturn(Optional.empty());
+
+        // when
+        userProfileUpdateService.changeNickname(user, newNick);
+
+        // then
+        assertEquals(newNick, user.getNickname());
+        verify(userProfilePolicy).isNicknameValid(newNick);
+        verify(userRepository).findByNickname(newNick);
+    }
+
+    @Test
+    @DisplayName("닉네임이 정책을 위반하면 예외 발생")
+    void changeNickname_invalidByPolicy() {
+        // given
+        User user = new User();
+        String badNick = "??";
+
+        given(userProfilePolicy.isNicknameValid(badNick)).willReturn(false);
+
+        // when / then
+        assertThrows(IllegalArgumentException.class,
+                () -> userProfileUpdateService.changeNickname(user, badNick),
+                "해당 닉네임은 정책상 사용할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("닉네임이 중복이면 예외 발생")
+    void changeNickname_duplicateNickname() {
+        // given
+        User user = new User();
+        String dupNick = "taken";
+
+        given(userProfilePolicy.isNicknameValid(dupNick)).willReturn(true);
+        given(userRepository.findByNickname(dupNick)).willReturn(Optional.of(new User()));
+
+        // when / then
+        assertThrows(IllegalArgumentException.class,
+                () -> userProfileUpdateService.changeNickname(user, dupNick),
+                "해당 닉네임은 다른 사용자가 사용 중입니다.");
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

나의 회원 정보 조회/수정 및 닉네임 중복확인 API를 구현했습니다.
또한 애플 소셜 로그인 응답에 signupStatus를 추가했습니다. (회원가입 절차 완료 여부 확인 가능)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.