### PR TITLE
feat(map): 주위의 컬렉션 조회 API 구현 (지도)

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -1,6 +1,7 @@
 package org.devkor.apu.saerok_server.domain.collection.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -372,24 +373,38 @@ public class CollectionController {
     @GetMapping("/nearby")
     @PermitAll
     @Operation(
-            summary = "주위의 컬렉션 조회 (우리 지도)",
+            summary = "주위의 컬렉션 조회",
             security = @SecurityRequirement(name = "bearerAuth"),
             description = """
                     주위의 컬렉션을 조회합니다.
+                    
+                    내 지도 기능은 isMineOnly = true, 우리 지도 기능은 false를 사용하면 됩니다.
+                     - 비회원인데 isMineOnly = true이면 400 Bad Request
                     """,
             responses = {
-                    @ApiResponse(responseCode = "200", description = "컬렉션 이미지 삭제 성공")
+                    @ApiResponse(
+                            responseCode = "200", description = "조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = GetNearbyCollectionsResponse.class)
+                            )
+                    ),
             }
     )
     public GetNearbyCollectionsResponse getNearbyCollections(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Parameter(description = "검색 중심 위도", example = "37.5665", required = true)
             @RequestParam Double latitude,
+            @Parameter(description = "검색 중심 경도", example = "126.9780", required = true)
             @RequestParam Double longitude,
-            @RequestParam Double radiusMeters
+            @Parameter(description = "검색 반경 (m)", example = "500", required = true)
+            @RequestParam Double radiusMeters,
+            @Parameter(description = "주위의 내 컬렉션만 조회 여부. 비회원은 false만 허용", example = "false")
+            @RequestParam(required = false, defaultValue = "false") Boolean isMineOnly
     ) {
         Long userId = userPrincipal == null ? null : userPrincipal.getId();
         return collectionQueryService.getNearbyCollections(
-                new GetNearbyCollectionsCommand(userId, latitude, longitude, radiusMeters)
+                new GetNearbyCollectionsCommand(userId, latitude, longitude, radiusMeters, isMineOnly)
         );
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -1,6 +1,7 @@
 package org.devkor.apu.saerok_server.domain.collection.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -84,24 +85,13 @@ public class CollectionController {
                     )
             ),
             responses = {
-                    @ApiResponse(
-                            responseCode = "201",
-                            description = "컬렉션 생성 성공",
+                    @ApiResponse(responseCode = "201", description = "컬렉션 생성 성공",
                             content = @Content(
-                                    schema = @Schema(implementation = CreateCollectionResponse.class),
-                                    mediaType = "application/json"
+                                    schema = @Schema(implementation = CreateCollectionResponse.class)
                             )
                     ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 요청",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "사용자 인증 실패",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
             }
     )
     @ResponseStatus(HttpStatus.CREATED)
@@ -157,29 +147,14 @@ public class CollectionController {
                     )
             ),
             responses = {
-                    @ApiResponse(
-                            responseCode = "201",
-                            description = "컬렉션 이미지 업로드 주소 발급 성공",
+                    @ApiResponse(responseCode = "201", description = "컬렉션 이미지 업로드 주소 발급 성공",
                             content = @Content(
-                                    schema = @Schema(implementation = PresignResponse.class),
-                                    mediaType = "application/json"
+                                    schema = @Schema(implementation = PresignResponse.class)
                             )
                     ),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "사용자 인증 실패",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "403",
-                            description = "해당 컬렉션에 대한 권한 없음 (다른 사용자의 컬렉션 id로 요청한 경우)",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "존재하지 않는 컬렉션 (유효하지 않은 컬렉션 id)",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    )
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "해당 컬렉션에 대한 권한 없음 (다른 사용자의 컬렉션 id로 요청한 경우)", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 컬렉션 (유효하지 않은 컬렉션 id)", content = @Content),
             }
     )
     @ResponseStatus(HttpStatus.CREATED)
@@ -210,29 +185,14 @@ public class CollectionController {
         📌 반드시 `컬렉션 생성 API → presigned URL 발급 API → 해당 URL로 이미지 업로드 → 이미지 메타데이터 등록 API`의 순서를 따라야 합니다.
         """,
             responses = {
-                    @ApiResponse(
-                            responseCode = "201",
-                            description = "컬렉션 이미지 메타데이터 등록 성공",
+                    @ApiResponse(responseCode = "201", description = "컬렉션 이미지 메타데이터 등록 성공",
                             content = @Content(
-                                    schema = @Schema(implementation = CreateCollectionImageResponse.class),
-                                    mediaType = "application/json"
+                                    schema = @Schema(implementation = CreateCollectionImageResponse.class)
                             )
                     ),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "사용자 인증 실패",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "403",
-                            description = "해당 컬렉션에 대한 권한 없음 (다른 사용자의 컬렉션 id로 요청한 경우)",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "존재하지 않는 컬렉션 (유효하지 않은 컬렉션 id)",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    )
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "해당 컬렉션에 대한 권한 없음 (다른 사용자의 컬렉션 id로 요청한 경우)", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 컬렉션 (유효하지 않은 컬렉션 id)", content = @Content),
             }
     )
     public CreateCollectionImageResponse notifyImageUpload(
@@ -286,19 +246,16 @@ public class CollectionController {
             """,
             responses = {
                     @ApiResponse(
-                            responseCode = "200",
-                            description = "목록 조회 성공"
+                            responseCode = "200", description = "목록 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    array = @ArraySchema(
+                                            schema = @Schema(implementation = MyCollectionsResponse.class)
+                                    )
+                            )
                     ),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "사용자 인증 실패",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    )
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content),
             }
     )
     public List<MyCollectionsResponse> listMyCollections(
@@ -317,26 +274,10 @@ public class CollectionController {
                     컬렉션 수정 시 필요한 정보를 조회합니다.
                     """,
             responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "조회 성공",
-                            content = @Content(schema = @Schema(implementation = GetCollectionEditDataResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "사용자 인증 실패",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "403",
-                            description = "권한 없음",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "컬렉션 없음",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    )
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "컬렉션 없음", content = @Content),
             }
     )
     public GetCollectionEditDataResponse getCollectionEditData(
@@ -365,14 +306,10 @@ public class CollectionController {
             """,
             responses = {
                     @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = UpdateCollectionResponse.class))),
-                    @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "사용자 인증 실패",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "요청한 자원이 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "요청한 자원이 없음", content = @Content),
             }
     )
     public UpdateCollectionResponse updateCollection(
@@ -394,13 +331,9 @@ public class CollectionController {
             """,
             responses = {
                     @ApiResponse(responseCode = "204", description = "컬렉션 삭제 성공"),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "사용자 인증 실패",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(responseCode = "403", description = "해당 컬렉션에 대한 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "요청한 컬렉션이 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "해당 컬렉션에 대한 권한 없음", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "요청한 컬렉션이 없음", content = @Content),
             }
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -424,13 +357,9 @@ public class CollectionController {
                     """,
             responses = {
                     @ApiResponse(responseCode = "204", description = "컬렉션 이미지 삭제 성공"),
-                    @ApiResponse(
-                            responseCode = "401",
-                            description = "사용자 인증 실패",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-                    ),
-                    @ApiResponse(responseCode = "403", description = "해당 컬렉션에 대한 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "요청한 자원이 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "해당 컬렉션에 대한 권한 없음", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "요청한 자원이 없음", content = @Content),
             }
     )
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -9,21 +9,18 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import lombok.RequiredArgsConstructor;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CollectionImagePresignRequest;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionImageRequest;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionRequest;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.request.*;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionImageResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionDetailResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.MyCollectionsResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.PresignResponse;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.request.UpdateCollectionRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.*;
 import org.devkor.apu.saerok_server.domain.collection.application.CollectionCommandService;
 import org.devkor.apu.saerok_server.domain.collection.application.CollectionImageCommandService;
 import org.devkor.apu.saerok_server.domain.collection.application.CollectionQueryService;
+import org.devkor.apu.saerok_server.domain.collection.application.dto.GetNearbyCollectionsCommand;
 import org.devkor.apu.saerok_server.domain.collection.mapper.CollectionWebMapper;
-import org.devkor.apu.saerok_server.global.exception.ErrorResponse;
 import org.devkor.apu.saerok_server.global.security.UserPrincipal;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -370,5 +367,29 @@ public class CollectionController {
     ) {
         Long userId = userPrincipal.getId();
         collectionImageCommandService.deleteCollectionImage(userId, collectionId, imageId);
+    }
+
+    @GetMapping("/nearby")
+    @PermitAll
+    @Operation(
+            summary = "주위의 컬렉션 조회 (우리 지도)",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            description = """
+                    주위의 컬렉션을 조회합니다.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "컬렉션 이미지 삭제 성공")
+            }
+    )
+    public GetNearbyCollectionsResponse getNearbyCollections(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam Double latitude,
+            @RequestParam Double longitude,
+            @RequestParam Double radiusMeters
+    ) {
+        Long userId = userPrincipal == null ? null : userPrincipal.getId();
+        return collectionQueryService.getNearbyCollections(
+                new GetNearbyCollectionsCommand(userId, latitude, longitude, radiusMeters)
+        );
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
@@ -1,5 +1,6 @@
 package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -7,15 +8,24 @@ import java.util.List;
 
 @Data
 @NoArgsConstructor
+@Schema(description = "주위의 컬렉션 조회 응답 DTO")
 public class GetNearbyCollectionsResponse {
 
+    @Schema(description = "주위의 컬렉션 목록")
     private List<Item> items;
 
     @Data
     public static class Item {
+        @Schema(description = "컬렉션 ID", example = "1")
         private Long collectionId;
+
+        @Schema(description = "이미지 URL", example = "https://cdn.example.com/collection-images/1.jpg")
         private String imageUrl;
+
+        @Schema(description = "새 한국어 이름", example = "까치")
         private String koreanName;
+
+        @Schema(description = "한 줄 평", example = "광화문에서 까치가 날아다녔어요")
         private String note;
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
@@ -1,0 +1,21 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class GetNearbyCollectionsResponse {
+
+    private List<Item> items;
+
+    @Data
+    public static class Item {
+        private Long collectionId;
+        private String imageUrl;
+        private String koreanName;
+        private String note;
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/MyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/MyCollectionsResponse.java
@@ -1,16 +1,17 @@
 package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
-
-import java.util.List;
 
 @Data
 @Schema(description = "내 컬렉션 목록 조회 응답")
 public class MyCollectionsResponse {
+    @Schema(description = "컬렉션 ID", example = "1")
     private Long collectionId;
+
+    @Schema(description = "이미지 URL", example = "https://example.com/images/collection1.jpg")
     private String imageUrl;
+
+    @Schema(description = "새 이름", example = "까치")
     private String birdName;
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
@@ -87,7 +87,7 @@ public class CollectionCommandService {
     }
 
     public void deleteCollection(DeleteCollectionCommand command) {
-        User user = userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
+        userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
         UserBirdCollection collection = collectionRepository.findById(command.collectionId()).orElseThrow(() -> new NotFoundException("해당 id의 컬렉션이 존재하지 않아요"));
         if (!command.userId().equals(collection.getUser().getId())) {
             throw new ForbiddenException("해당 컬렉션에 대한 권한이 없어요");
@@ -113,7 +113,7 @@ public class CollectionCommandService {
     }
 
     public UpdateCollectionResponse updateCollection(UpdateCollectionCommand command) {
-        User user = userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
+        userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
         UserBirdCollection collection = collectionRepository.findById(command.collectionId()).orElseThrow(() -> new NotFoundException("해당 id의 컬렉션이 존재하지 않아요"));
         if (!command.userId().equals(collection.getUser().getId())) {
             throw new ForbiddenException("해당 컬렉션에 대한 권한이 없어요");

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
@@ -9,6 +9,7 @@ import org.devkor.apu.saerok_server.domain.collection.application.dto.UpdateColl
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionImageRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
+import org.devkor.apu.saerok_server.domain.collection.infra.PointFactory;
 import org.devkor.apu.saerok_server.domain.collection.mapper.CollectionWebMapper;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.Bird;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.repository.BirdRepository;
@@ -41,6 +42,7 @@ public class CollectionCommandService {
     private final CollectionImageRepository collectionImageRepository;
     private final CloudFrontUrlService cloudFrontUrlService;
     private final CollectionWebMapper collectionWebMapper;
+    private final PointFactory pointFactory;
 
     @Value("${aws.s3.bucket}")
     private String bucket;
@@ -68,9 +70,7 @@ public class CollectionCommandService {
             throw new BadRequestException("한 줄 평 길이는 " + UserBirdCollection.NOTE_MAX_LENGTH + "자 이하여야 해요");
         }
 
-        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
-        Coordinate coordinate = new Coordinate(command.longitude(), command.latitude());
-        Point location = geometryFactory.createPoint(coordinate);
+        Point location = pointFactory.create(command.latitude(), command.longitude());
 
         UserBirdCollection collection = UserBirdCollection.builder()
                 .user(user)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
@@ -98,8 +98,16 @@ public class CollectionQueryService {
     }
 
     public GetNearbyCollectionsResponse getNearbyCollections(GetNearbyCollectionsCommand command) {
+        if (command.userId() != null) {
+            userRepository.findById(command.userId()).orElseThrow(() -> new NotFoundException("유효하지 않은 사용자 id예요"));
+        }
+
+        if (command.userId() == null && command.isMineOnly()) {
+            throw new BadRequestException("비회원 사용자는 isMineOnly = false만 사용 가능해요.");
+        }
+
         Point refPoint = pointFactory.create(command.latitude(), command.longitude());
-        List<UserBirdCollection> collections = collectionRepository.findNearby(refPoint, command.radiusMeters(), command.userId());
+        List<UserBirdCollection> collections = collectionRepository.findNearby(refPoint, command.radiusMeters(), command.userId(), command.isMineOnly());
 
         List<GetNearbyCollectionsResponse.Item> items = collections.stream()
                 .map(collection -> {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/GetNearbyCollectionsCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/GetNearbyCollectionsCommand.java
@@ -1,0 +1,9 @@
+package org.devkor.apu.saerok_server.domain.collection.application.dto;
+
+public record GetNearbyCollectionsCommand(
+        Long userId,
+        Double latitude,
+        Double longitude,
+        Double radiusMeters
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/GetNearbyCollectionsCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/GetNearbyCollectionsCommand.java
@@ -4,6 +4,7 @@ public record GetNearbyCollectionsCommand(
         Long userId,
         Double latitude,
         Double longitude,
-        Double radiusMeters
+        Double radiusMeters,
+        boolean isMineOnly
 ) {
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/infra/PointFactory.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/infra/PointFactory.java
@@ -1,0 +1,17 @@
+package org.devkor.apu.saerok_server.domain.collection.infra;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PointFactory {
+
+    public Point create(double latitude, double longitude) {
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        Coordinate coordinate = new Coordinate(longitude, latitude);
+        return geometryFactory.createPoint(coordinate);
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -3,13 +3,10 @@ package org.devkor.apu.saerok_server.domain.collection.mapper;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionImageRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.CreateCollectionRequest;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.request.UpdateCollectionRequest;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.CreateCollectionResponse;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionDetailResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.*;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionCommand;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.CreateCollectionImageCommand;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.DeleteCollectionCommand;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionEditDataResponse;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.UpdateCollectionResponse;
 import org.devkor.apu.saerok_server.domain.collection.application.dto.*;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
 import org.mapstruct.Mapper;
@@ -58,6 +55,10 @@ public interface CollectionWebMapper {
     @Mapping(target = "collectionId", source = "collection.id")
     @Mapping(target = "user.userId", source = "collection.user.id")
     GetCollectionDetailResponse toGetCollectionDetailResponse(UserBirdCollection collection, String imageUrl);
+
+    @Mapping(target = "collectionId", source = "collection.id")
+    @Mapping(target = "koreanName", source = "collection.bird.name.koreanName")
+    GetNearbyCollectionsResponse.Item toGetNearbyCollectionsResponseItem(UserBirdCollection collection, String imageUrl);
 
     @Named("getBirdId")
     default Long getBirdId(UserBirdCollection collection) {

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryServiceTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryServiceTest.java
@@ -5,6 +5,7 @@ import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelTyp
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionImageRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
+import org.devkor.apu.saerok_server.domain.collection.infra.PointFactory;
 import org.devkor.apu.saerok_server.domain.collection.mapper.CollectionWebMapper;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
@@ -39,6 +40,7 @@ class CollectionQueryServiceTest {
     @Mock CollectionWebMapper collectionWebMapper;
     @Mock UserRepository userRepository;
     @Mock CloudFrontUrlService cloudFrontUrlService;
+    @Mock PointFactory pointFactory;
 
     Field userIdField;
     Field collectionIdField;
@@ -51,7 +53,8 @@ class CollectionQueryServiceTest {
                 collectionImageRepository,
                 collectionWebMapper,
                 userRepository,
-                cloudFrontUrlService
+                cloudFrontUrlService,
+                pointFactory
         );
 
         userIdField = User.class.getDeclaredField("id");

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionRepositoryTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionRepositoryTest.java
@@ -1,0 +1,154 @@
+package org.devkor.apu.saerok_server.domain.collection.core.repository;
+
+import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.testsupport.AbstractPostgresContainerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import(CollectionRepository.class)
+@ActiveProfiles("test")
+class CollectionRepositoryTest extends AbstractPostgresContainerTest {
+
+    @Autowired
+    CollectionRepository collectionRepository;
+
+    @Autowired
+    TestEntityManager em;
+
+    GeometryFactory gf;
+
+    Field collUserField;
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException {
+        gf = new GeometryFactory();
+
+        collUserField = UserBirdCollection.class.getDeclaredField("user");
+        collUserField.setAccessible(true);
+    }
+
+    /* ------------------------------------------------------------------
+     * helpers
+     * ------------------------------------------------------------------ */
+    private User newUser() {
+        User u = new User();
+        em.persist(u);
+        return u;
+    }
+
+    private UserBirdCollection newCollection(
+            User owner,
+            Point point,
+            AccessLevelType accessLevel
+    ) throws IllegalAccessException {
+        UserBirdCollection c = new UserBirdCollection();
+        collUserField.set(c, owner);
+        c.setLocation(point);
+        c.setAccessLevel(accessLevel);
+        c.setDiscoveredDate(LocalDate.now());
+        em.persist(c);
+        return c;
+    }
+
+    /* ------------------------------------------------------------------
+     * tests
+     * ------------------------------------------------------------------ */
+
+    @Test
+    @DisplayName("isMineOnly=true 이면 같은 반경 내 ‘내 컬렉션’만 조회")
+    void findNearby_mineOnly_returnsOnlyMyCollections() throws Exception {
+        // given
+        User me = newUser();
+        User other = newUser();
+
+        Point ref = gf.createPoint(new Coordinate(126.9780, 37.5665));   // 서울시청
+        Point near = gf.createPoint(new Coordinate(126.9779, 37.5666));
+        Point far  = gf.createPoint(new Coordinate(127.0000, 37.5800));  // 반경 밖
+
+        UserBirdCollection myColl   = newCollection(me, near, AccessLevelType.PRIVATE);
+        newCollection(other, near, AccessLevelType.PUBLIC);              // 우리 지도용
+        newCollection(other, far,  AccessLevelType.PUBLIC);              // 반경 밖
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<UserBirdCollection> result =
+                collectionRepository.findNearby(ref, 1_000, me.getId(), true);
+
+        // then
+        assertEquals(1, result.size(), "mineOnly=true 이므로 한 개만 반환");
+        assertEquals(myColl.getId(), result.getFirst().getId());
+    }
+
+    @Test
+    @DisplayName("isMineOnly=false 이면 PUBLIC + 내 컬렉션이 모두 조회")
+    void findNearby_all_returnsPublicAndMyCollections() throws Exception {
+        // given
+        User me = newUser();
+        User other = newUser();
+
+        Point ref = gf.createPoint(new Coordinate(126.9780, 37.5665));
+        Point near = gf.createPoint(new Coordinate(126.9781, 37.5664));
+        Point far = gf.createPoint(new Coordinate(127.0000, 37.6000));
+
+        UserBirdCollection myColl       = newCollection(me, near, AccessLevelType.PRIVATE);
+        UserBirdCollection publicColl   = newCollection(other, near, AccessLevelType.PUBLIC);
+        newCollection(other, near, AccessLevelType.PRIVATE);  // 다른 사람의 PRIVATE 컬렉션 - should be filtered
+        newCollection(me, far, AccessLevelType.PUBLIC); // 반경 밖의 내 컬렉션 - should be filtered
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<UserBirdCollection> result =
+                collectionRepository.findNearby(ref, 1_000, me.getId(), false);
+
+        // then
+        assertEquals(2, result.size(), "PUBLIC + 내 컬렉션 두 개 조회");
+        assertTrue(result.stream().anyMatch(c -> c.getId().equals(myColl.getId())));
+        assertTrue(result.stream().anyMatch(c -> c.getId().equals(publicColl.getId())));
+    }
+
+    @Test
+    @DisplayName("익명 호출 시 PUBLIC 컬렉션만 조회")
+    void findNearby_anonymous_returnsOnlyPublic() throws Exception {
+        // given
+        User owner = newUser();
+
+        Point ref = gf.createPoint(new Coordinate(126.9780, 37.5665));
+        Point near = gf.createPoint(new Coordinate(126.9782, 37.5663));
+
+        UserBirdCollection publicColl  = newCollection(owner, near, AccessLevelType.PUBLIC);
+        newCollection(owner, near, AccessLevelType.PRIVATE);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<UserBirdCollection> result =
+                collectionRepository.findNearby(ref, 1_000, null, false);
+
+        // then
+        assertEquals(1, result.size(), "PUBLIC 하나만 조회");
+        assertEquals(publicColl.getId(), result.getFirst().getId());
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

주위의 컬렉션 조회 API를 구현했습니다.

다음 3가지 케이스에 대응합니다.

- 내 지도 (반경 내 나의 컬렉션)
- 우리 지도 (반경 내 나의 컬렉션 + 반경 내 타인의 공개된 컬렉션)
- (비회원용) 우리 지도 (반경 내 타인의 공개된 컬렉션)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.