### PR TITLE
feat: 컬렉션 수정 계열 API 응답 수정 및 컬렉션 수정 API에 accessLevel 추가

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -285,18 +285,15 @@ public class CollectionController {
     @PatchMapping("/{collectionId}/edit")
     @PreAuthorize("hasRole('USER')")
     @Operation(
-            summary = "컬렉션 메타데이터 수정",
+            summary = "컬렉션 수정",
             security = @SecurityRequirement(name = "bearerAuth"),
             description = """
-            기존에 생성한 컬렉션의 메타데이터를 수정합니다.
+            기존에 생성한 컬렉션을 수정합니다.
             수정하고 싶은 필드만 요청 json에 담아서 보낼 수 있습니다.
             
-            birdId를 수정하려면 반드시 isBirdIdUpdated = true도 포함해야 합니다.
-            
-            ⚠️ 수정 대상: 이미지 제외한 컬렉션의 모든 메타데이터
-            
-            ✅ 유효성 조건:
-            - `note`는 50자 이하
+            - birdId를 수정하려면 반드시 isBirdIdUpdated = true도 포함해야 합니다.
+            - accessLevel 허용 값: PUBLIC, PRIVATE (대소문자 구분. 허용되지 않는 값 보내면 400)
+            - note는 50자 이하여야 합니다.
             """,
             responses = {
                     @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = UpdateCollectionResponse.class))),

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -268,7 +268,7 @@ public class CollectionController {
                     컬렉션 수정 시 필요한 정보를 조회합니다.
                     """,
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content),
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = GetCollectionEditDataResponse.class))),
                     @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
                     @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
                     @ApiResponse(responseCode = "404", description = "컬렉션 없음", content = @Content),

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -2,7 +2,6 @@ package org.devkor.apu.saerok_server.domain.collection.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/UpdateCollectionRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/UpdateCollectionRequest.java
@@ -3,6 +3,7 @@ package org.devkor.apu.saerok_server.domain.collection.api.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
 
 import java.time.LocalDate;
 
@@ -34,4 +35,7 @@ public class UpdateCollectionRequest {
 
     @Schema(description = "관찰 기록에 대한 간단한 메모", example = "까치가 엄청 날아다녔다", nullable = true)
     private String note;
+
+    @Schema(description = "공개/비공개 여부", example = "PUBLIC", nullable = true)
+    private AccessLevelType accessLevel;
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
@@ -37,18 +37,9 @@ public class GetCollectionEditDataResponse {
     @Schema(description = "컬렉션 공개 범위 (공개/비공개)")
     private AccessLevelType accessLevel;
 
-    @Schema(description = "컬렉션에 첨부된 이미지 정보 목록")
-    private List<ImageInfo> images;
+    @Schema(description = "이미지 ID", example = "300")
+    private Long imageId;
 
-    @Data
-    @AllArgsConstructor
-    @Schema(description = "이미지 정보")
-    public static class ImageInfo {
-
-        @Schema(description = "이미지 ID", example = "300")
-        private Long id;
-
-        @Schema(description = "이미지 URL", example = "https://cdn.example.com/images/300.jpg")
-        private String url;
-    }
+    @Schema(description = "이미지 URL", example = "https://cdn.example.com/images/300.jpg")
+    private String imageUrl;
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
@@ -1,13 +1,10 @@
 package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
-import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Data
 @Schema(description = "컬렉션 수정용 상세 조회 응답 DTO")

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
@@ -1,17 +1,38 @@
 package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
 
-import java.time.LocalDate;
-import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
 
-public record UpdateCollectionResponse (
+import java.time.LocalDate;
+
+public record UpdateCollectionResponse(
+        @Schema(description = "컬렉션 ID", example = "1")
         Long collectionId,
+
+        @Schema(description = "관찰한 새의 ID", example = "10", nullable = true)
         Long birdId,
+
+        @Schema(description = "관찰한 날짜 (yyyy-MM-dd 형식)", example = "2024-05-15")
         LocalDate discoveredDate,
+
+        @Schema(description = "경도", example = "126.5583")
         Double longitude,
+
+        @Schema(description = "위도", example = "33.2395")
         Double latitude,
+
+        @Schema(description = "주소", example = "제주특별자치도 서귀포시 안덕면 사계리", nullable = true)
         String address,
+
+        @Schema(description = "사용자 지정 장소 별칭", example = "서귀포 갯벌", nullable = true)
         String locationAlias,
+
+        @Schema(description = "한 줄 평", example = "까치가 엄청 날아다녔다", nullable = true)
         String note,
-        String imageUrl
-) {
-}
+
+        @Schema(description = "이미지 URL", example = "https://cdn.example.com/collection/1.jpg", nullable = true)
+        String imageUrl,
+
+        @Schema(description = "공개/비공개 여부", example = "PUBLIC", nullable = true)
+        AccessLevelType accessLevel
+) {}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
@@ -12,6 +12,6 @@ public record UpdateCollectionResponse (
         String address,
         String locationAlias,
         String note,
-        List<String> imageUrls
+        String imageUrl
 ) {
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
@@ -130,6 +130,10 @@ public class CollectionCommandService {
             collection.setNote(command.note());
         }
 
+        if (command.accessLevel() != null) {
+            collection.setAccessLevel(command.accessLevel());
+        }
+
         String imageUrl = collectionImageRepository.findObjectKeysByCollectionId(command.collectionId()).stream()
                 .map(cloudFrontUrlService::toImageUrl)
                 .findFirst()

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommandService.java
@@ -26,8 +26,6 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -132,10 +130,11 @@ public class CollectionCommandService {
             collection.setNote(command.note());
         }
 
-        List<String> urls = collectionImageRepository.findObjectKeysByCollectionId(command.collectionId()).stream()
+        String imageUrl = collectionImageRepository.findObjectKeysByCollectionId(command.collectionId()).stream()
                 .map(cloudFrontUrlService::toImageUrl)
-                .toList();
+                .findFirst()
+                .orElse(null);
 
-        return collectionWebMapper.toUpdateCollectionResponse(collection, urls);
+        return collectionWebMapper.toUpdateCollectionResponse(collection, imageUrl);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
@@ -9,7 +9,6 @@ import org.devkor.apu.saerok_server.domain.collection.application.dto.GetCollect
 import org.devkor.apu.saerok_server.domain.collection.application.dto.GetNearbyCollectionsCommand;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
-import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionImage;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionImageRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.util.PointFactory;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
@@ -44,14 +44,20 @@ public class CollectionQueryService {
         }
 
         GetCollectionEditDataResponse response = collectionWebMapper.toGetCollectionEditDataResponse(collection);
-        List<UserBirdCollectionImage> images = collectionImageRepository.findByCollectionId(command.collectionId());
-        List<GetCollectionEditDataResponse.ImageInfo> imageInfos = images.stream()
-                .map(image -> new GetCollectionEditDataResponse.ImageInfo(
-                            image.getId(),
-                            cloudFrontUrlService.toImageUrl(image.getObjectKey())
-                    ))
-                .toList();
-        response.setImages(imageInfos);
+        collectionImageRepository.findByCollectionId(command.collectionId())
+                .stream()
+                .findFirst()
+                .ifPresentOrElse(
+                        image -> {
+                            response.setImageId(image.getId());
+                            response.setImageUrl(cloudFrontUrlService.toImageUrl(image.getObjectKey()));
+                        },
+                        () -> {
+                            response.setImageId(null);
+                            response.setImageUrl(null);
+                        }
+                );
+
         return response;
     }
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/UpdateCollectionCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/dto/UpdateCollectionCommand.java
@@ -1,5 +1,7 @@
 package org.devkor.apu.saerok_server.domain.collection.application.dto;
 
+import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
+
 import java.time.LocalDate;
 
 public record UpdateCollectionCommand (
@@ -12,6 +14,7 @@ public record UpdateCollectionCommand (
         Double longitude,
         String locationAlias,
         String address,
-        String note
+        String note,
+        AccessLevelType accessLevel
 ){
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -14,8 +14,6 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.Named;
 
-import java.util.List;
-
 @Mapper(
         componentModel = MappingConstants.ComponentModel.SPRING
 )

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -45,9 +45,8 @@ public interface CollectionWebMapper {
     UpdateCollectionCommand toUpdateCollectionCommand(UpdateCollectionRequest request, Long userId, Long collectionId);
 
     @Mapping(target = "birdId", source = "collection.bird.id")
-    @Mapping(target = "imageUrls", source = "imageUrls")
     @Mapping(target = "collectionId", source = "collection.id")
-    UpdateCollectionResponse toUpdateCollectionResponse(UserBirdCollection collection, List<String> imageUrls);
+    UpdateCollectionResponse toUpdateCollectionResponse(UserBirdCollection collection, String imageUrl);
 
     @Mapping(target = "bird.birdId", source = "collection", qualifiedByName = "getBirdId")
     @Mapping(target = "bird.koreanName", source = "collection", qualifiedByName = "getBirdKoreanName")

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -38,7 +38,6 @@ public interface CollectionWebMapper {
     GetCollectionEditDataCommand toGetCollectionDataCommand(Long userId, Long collectionId);
 
     @Mapping(target = "birdId", source = "bird.id")
-    @Mapping(target = "images", ignore = true)
     GetCollectionEditDataResponse toGetCollectionEditDataResponse(UserBirdCollection collection);
 
     @Mapping(target = "userId", source = "userId")


### PR DESCRIPTION
## 📝 요약(Summary)

- 컬렉션 수정 API 응답 수정 (imageUrls -> imageUrl)
- 컬렉션 수정용 상세 조회 API 응답 수정 (images[0].id, images[0].url -> imageId, imageUrl)
- 컬렉션 수정 API에 accessLevel 추가 (공개, 비공개 수정 가능)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.