### PR TITLE
feat: 카카오 소셜 로그인 API HTTP 메서드 변경 (GET -> POST)

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/AuthController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/AuthController.java
@@ -19,7 +19,6 @@ import org.devkor.apu.saerok_server.domain.auth.application.TokenRefreshService;
 import org.devkor.apu.saerok_server.global.exception.UnauthorizedException;
 import org.devkor.apu.saerok_server.global.util.ClientInfoExtractor;
 import org.devkor.apu.saerok_server.global.util.dto.ClientInfo;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -70,7 +69,7 @@ public class AuthController {
         return appleAuthService.authenticate(request.authorizationCode(), null, clientInfo);
     }
 
-    @GetMapping("/kakao/login") // 카카오 인증 절차상 GET 요청으로 설정해야 함 (302 Redirect)
+    @PostMapping("/kakao/login")
     @PermitAll
     @Operation(
             summary = "Kakao 소셜 로그인",
@@ -99,16 +98,11 @@ public class AuthController {
             }
     )
     public ResponseEntity<AccessTokenResponse> kakaoLogin(
-            @ParameterObject @ModelAttribute KakaoLoginRequest request,
+            @RequestBody KakaoLoginRequest request,
             HttpServletRequest httpServletRequest
     ) {
-        if (request.getError() == null) {
-            ClientInfo clientInfo = clientInfoExtractor.extract(httpServletRequest);
-            return kakaoAuthService.authenticate(request.getCode(), request.getAccessToken(), clientInfo);
-        }
-
-        String errorMessage = "카카오 로그인 인증에 실패했어요: " + request.getError() + ", " + request.getErrorDescription();
-        throw new UnauthorizedException(errorMessage);
+        ClientInfo clientInfo = clientInfoExtractor.extract(httpServletRequest);
+        return kakaoAuthService.authenticate(request.getAuthorizationCode(), request.getAccessToken(), clientInfo);
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/request/KakaoLoginRequest.java
@@ -1,6 +1,5 @@
 package org.devkor.apu.saerok_server.domain.auth.api.dto.request;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -8,21 +7,9 @@ import lombok.Data;
 public class KakaoLoginRequest {
 
     @Schema(description = "인가 코드")
-    private String code;
+    private String authorizationCode;
 
-    @Schema(description = "액세스 토큰 (카카오 인증 서버에서 받은 액세스 토큰)")
+    @Schema(description = "액세스 토큰")
     private String accessToken;
-
-    @Hidden
-    private String error;
-
-    @Hidden
-    @Schema(name = "error_description")
-    private String errorDescription;
-
-    public void setError_description(String error_description) {
-        this.errorDescription = error_description;
-    }
-    // 쿼리 파라미터 error_description을 String errorDescription 변수에 매핑하기 위함
 
 }


### PR DESCRIPTION
## 📝 요약(Summary)

카카오 소셜 로그인 API HTTP 메서드를 GET에서 POST로 변경했습니다
이에 따라 기존 쿼리 파라미터 방식(`/kakao/login?accessToken=abc`)이 아닌 JSON body로 인가 코드 또는 액세스 토큰을 보내야 합니다

## 📸스크린샷 (선택)

![image](https://github.com/user-attachments/assets/520c9190-b584-4de2-a156-aa97324fd855)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.