### PR TITLE
feat(user): 회원 정보 조회에 가입 일자 포함

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/api/response/GetMyUserProfileResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/api/response/GetMyUserProfileResponse.java
@@ -1,7 +1,10 @@
 package org.devkor.apu.saerok_server.domain.user.api.response;
 
+import java.time.LocalDate;
+
 public record GetMyUserProfileResponse(
         String nickname,
-        String email
+        String email,
+        LocalDate joinedDate
 ) {
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserQueryService.java
@@ -8,6 +8,7 @@ import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
 import org.devkor.apu.saerok_server.domain.user.core.dto.NicknameValidationResult;
 import org.devkor.apu.saerok_server.domain.user.core.service.UserProfilePolicy;
 import org.devkor.apu.saerok_server.global.exception.NotFoundException;
+import org.devkor.apu.saerok_server.global.util.OffsetDateTimeLocalizer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +25,8 @@ public class UserQueryService {
 
         return new GetMyUserProfileResponse(
                 user.getNickname(),
-                user.getEmail()
+                user.getEmail(),
+                OffsetDateTimeLocalizer.toSeoulLocalDate(user.getJoinedAt())
         );
     }
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/User.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/User.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import org.devkor.apu.saerok_server.global.entity.SoftDeletableAuditable;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 
 @Entity
 @Table(name = "users")
@@ -38,10 +39,19 @@ public class User extends SoftDeletableAuditable {
     @Setter
     private SignupStatusType signupStatus;
 
+    @Column(name = "joined_at")
+    private OffsetDateTime joinedAt;
+
     public static User createUser(String email) {
         User user = new User();
         user.email = email;
         user.signupStatus = SignupStatusType.PROFILE_REQUIRED;
         return user;
+    }
+
+    @Override
+    protected void postOnCreate() {
+        joinedAt = createdAt;
+        // 최초 가입 시 joinedAt 세팅. 탈퇴 후 재가입 시 joinedAt 세팅은 이와 별도로 처리해야 함
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/entity/Auditable.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/entity/Auditable.java
@@ -20,7 +20,11 @@ public abstract class Auditable {
     protected void onCreate() {
         createdAt = OffsetDateTime.now();
         updatedAt = createdAt;
+        postOnCreate();
     }
+
+    // 각 엔티티별로 INSERT 시점에 추가 로직을 실행하고 싶을 때 override해서 쓸 수 있는 hook
+    protected void postOnCreate() {}
 
     @PreUpdate
     protected void onUpdate() {

--- a/src/main/java/org/devkor/apu/saerok_server/global/util/OffsetDateTimeLocalizer.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/util/OffsetDateTimeLocalizer.java
@@ -1,0 +1,14 @@
+package org.devkor.apu.saerok_server.global.util;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+public class OffsetDateTimeLocalizer {
+
+    private static final ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
+
+    public static LocalDate toSeoulLocalDate(OffsetDateTime odt) {
+        return odt.atZoneSameInstant(seoulZoneId).toLocalDate();
+    }
+}

--- a/src/main/resources/db/migration/V21__add_joined_at_to_user.sql
+++ b/src/main/resources/db/migration/V21__add_joined_at_to_user.sql
@@ -1,0 +1,9 @@
+ALTER TABLE users ADD COLUMN joined_at TIMESTAMPTZ;
+UPDATE users SET joined_at = created_at;
+ALTER TABLE users ALTER COLUMN joined_at SET NOT NULL;
+
+/*
+초기에는 created_at을 가입 시각으로 겸할 수 있다고 판단했는데, 사용자 탈퇴 시 soft delete하는 것을 고려한다면, 가입 시각이라는 의미를 나타내는 필드를 별도로 두는 게 필요하다고 판단하여 추가.
+created_at을 재가입 시각으로 업데이트하는 것도 고려했으나 그것은 created_at의 의미와 맞지 않다고 판단.
+joined_at 필드는 최초 가입 또는 재가입 등 가장 최근의 가입 시각을 반영하는 필드.
+ */


### PR DESCRIPTION
## 📝 요약(Summary)

회원 정보 조회에 가입 일자를 포함시켰습니다.

## 공유 사항

users 테이블에 joined_at이라는 별도 필드를 추가했습니다
처음에는 created_at이 가입 일자 역할도 해줄 거라고 생각했는데, 사용자 탈퇴 시 soft delete했다가 재가입하는 상황을 생각했을 때, 가장 최근 가입 시각을 나타내는 별도 필드를 두는 것이 의미상 적절하겠다 싶더라구요 (created_at을 재가입할 때 변경하는 것은 부적절하다는 판단)

또 OffsetDateTimeLocalizer라는 유틸성 클래스를 하나 추가했어요. OffsetDateTime을 적절한 타임존의 (사실상 서울 기준) LocalDate 또는 LocalDateTime으로 변환해줄 책임을 갖는 녀석입니다. 사용자 가입 시각, 컬렉션(새록) 생성 시각 등등 잠재적으로 사용자에게 시각 또는 날짜 정보를 제공해줄 일이 생길 수 있는데, OffsetDateTime 타입을 그대로 제공한다면 그게 서울 기준이라는 보장이 없어서 이를 안전하게 서울 시각으로 변환해서 사용자에게 제공해줄 필요가 있거든요. 근데 이걸 매번 각 코드에서 일일이 서울 기준 LocalDate로 바꾸는 작업을 해서 코드 중복을 만들 가능성을 차단하기 위해 OffsetDateTimeLocalizer가 이 일을 맡게 한 것입니당

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.