### PR TITLE
chore: 운영 환경(prod)에서는 swagger 문서를 비공개

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/global/config/OpenApiConfig.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/config/OpenApiConfig.java
@@ -9,10 +9,12 @@ import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.util.List;
 
 @Configuration
+@Profile("!prod")
 public class OpenApiConfig {
 
     @Value("${swagger.server-url}")

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,8 +18,11 @@ spring:
 server:
   port: 8080
 
-swagger:
-  server-url: https://api.saerok.app
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
 
 aws:
   credentials:


### PR DESCRIPTION
## 📝 요약(Summary)

보안상 이유로 운영 도메인에서는 swagger 문서를 이용할 수 없게 처리함

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.