### PR TITLE
chore: 도감 이미지 버킷 dev/prod 분리

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -68,6 +68,8 @@ jobs:
             IAM_SECRET_KEY="${{ secrets.IAM_SECRET_KEY }}" \
             UPLOAD_IMAGE_BUCKET_NAME="${{ vars.UPLOAD_IMAGE_BUCKET_NAME }}" \
             UPLOAD_IMAGE_DOMAIN="${{ vars.UPLOAD_IMAGE_DOMAIN }}" \
+            DEX_IMAGE_BUCKET_NAME="${{ vars.DEX_IMAGE_BUCKET_NAME }}" \
+            DEX_IMAGE_DOMAIN="${{ vars.DEX_IMAGE_DOMAIN }}" \
             APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
             APPLE_TEAM_ID="${{ secrets.APPLE_TEAM_ID }}" \
             APPLE_KEY_ID="${{ secrets.APPLE_KEY_ID }}" \

--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -66,8 +66,10 @@ jobs:
             DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
             IAM_ACCESS_KEY="${{ secrets.IAM_ACCESS_KEY }}" \
             IAM_SECRET_KEY="${{ secrets.IAM_SECRET_KEY }}" \
-            BUCKET_NAME="${{ vars.UPLOAD_IMAGE_BUCKET_NAME }}" \
-            CLOUDFRONT_IMAGE_DOMAIN="${{ vars.UPLOAD_IMAGE_DOMAIN }}" \
+            UPLOAD_IMAGE_BUCKET_NAME="${{ vars.UPLOAD_IMAGE_BUCKET_NAME }}" \
+            UPLOAD_IMAGE_DOMAIN="${{ vars.UPLOAD_IMAGE_DOMAIN }}" \
+            DEX_IMAGE_BUCKET_NAME="${{ vars.DEX_IMAGE_BUCKET_NAME }}" \
+            DEX_IMAGE_DOMAIN="${{ vars.DEX_IMAGE_DOMAIN }}" \
             APPLE_CLIENT_ID="${{ secrets.APPLE_CLIENT_ID }}" \
             APPLE_TEAM_ID="${{ secrets.APPLE_TEAM_ID }}" \
             APPLE_KEY_ID="${{ secrets.APPLE_KEY_ID }}" \

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/core/entity/BirdImage.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/core/entity/BirdImage.java
@@ -16,11 +16,6 @@ public class BirdImage extends Auditable {
     @JoinColumn(name = "bird_id", nullable = false)
     private Bird bird;
 
-    @Column(name = "s3_url", nullable = false)
-    @Deprecated
-    private String s3Url;
-    // s3Url 대신 objectKey + ImageDomainService를 쓰는 방향으로 개선.
-
     @Column(name = "object_key", nullable = false)
     private String objectKey;
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/core/entity/BirdImage.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/core/entity/BirdImage.java
@@ -17,7 +17,12 @@ public class BirdImage extends Auditable {
     private Bird bird;
 
     @Column(name = "s3_url", nullable = false)
+    @Deprecated
     private String s3Url;
+    // s3Url 대신 objectKey + ImageDomainService를 쓰는 방향으로 개선.
+
+    @Column(name = "object_key", nullable = false)
+    private String objectKey;
 
     @Column(name = "original_url", nullable = false)
     private String originalUrl;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/core/mapper/BirdMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/core/mapper/BirdMapper.java
@@ -3,31 +3,37 @@ package org.devkor.apu.saerok_server.domain.dex.bird.core.mapper;
 import org.devkor.apu.saerok_server.domain.dex.bird.api.dto.response.BirdSearchResponse;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.Bird;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.BirdImage;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingConstants;
-import org.mapstruct.Named;
+import org.devkor.apu.saerok_server.global.util.ImageDomainService;
+import org.mapstruct.*;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
 @Mapper(
         componentModel = MappingConstants.ComponentModel.SPRING
 )
-public interface BirdMapper {
+public abstract class BirdMapper {
+
+    @Autowired
+    private ImageDomainService imageDomainService;
 
     @Mapping(source = "name.koreanName", target = "koreanName")
     @Mapping(source = "name.scientificName", target = "scientificName")
-    @Mapping(source = "images", target = "thumbImageUrl", qualifiedByName = "extractThumbImageUrl")
-    BirdSearchResponse.BirdSearchItem toDto(Bird bird);
+    @Mapping(target = "thumbImageUrl", ignore = true)
+    public abstract BirdSearchResponse.BirdSearchItem toDto(Bird bird);
 
-    List<BirdSearchResponse.BirdSearchItem> toDtoList(List<Bird> birds);
+    public abstract List<BirdSearchResponse.BirdSearchItem> toDtoList(List<Bird> birds);
 
-    @Named("extractThumbImageUrl")
-    default String extractThumbImageUrl(List<BirdImage> images) {
-        BirdImage birdImage = images.stream()
+    @AfterMapping
+    public void FillThumbImageUrl(
+            Bird source,
+            @MappingTarget BirdSearchResponse.BirdSearchItem target
+    ) {
+        String thumbImageUrl = source.getImages().stream()
                 .filter(BirdImage::isThumb)
+                .map(img -> imageDomainService.toDexImageUrl(img.getObjectKey()))
                 .findFirst()
                 .orElse(null);
-        return birdImage == null ? null : birdImage.getS3Url();
+        target.setThumbImageUrl(thumbImageUrl);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/view/BirdProfileView.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/view/BirdProfileView.java
@@ -77,8 +77,8 @@ public class BirdProfileView implements HasBodyLength {
     @Data
     public static class Image {
 
-        @JsonProperty("s3_url")
-        private String s3Url;
+        @JsonProperty("object_key")
+        private String objectKey;
 
         @JsonProperty("original_url")
         private String originalUrl;
@@ -92,10 +92,10 @@ public class BirdProfileView implements HasBodyLength {
 
     public String toSummaryString() {
         // 대표 이미지 URL (없으면 "N/A")
-        String thumbUrl = images != null
+        String objectKey = images != null
                 ? images.stream()
                 .filter(Image::getIsThumb)
-                .map(Image::getS3Url)
+                .map(Image::getObjectKey)
                 .findFirst()
                 .orElse("N/A")
                 : "N/A";
@@ -115,7 +115,7 @@ public class BirdProfileView implements HasBodyLength {
                 String.format("Body Length    : %.1f cm\n", bodyLengthCm) +
                 String.format("Habitats       : %s\n", habitats) +
                 String.format("Updated At     : %s\n", updatedAt) +
-                String.format("Thumbnail URL  : %s\n", thumbUrl);
+                String.format("Object Key  : %s\n", objectKey);
     }
 
     @Override

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bookmark/query/mapper/BookmarkMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bookmark/query/mapper/BookmarkMapper.java
@@ -1,6 +1,5 @@
 package org.devkor.apu.saerok_server.domain.dex.bookmark.query.mapper;
 
-import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.BirdImage;
 import org.devkor.apu.saerok_server.domain.dex.bookmark.api.dto.response.BookmarkResponse;
 import org.devkor.apu.saerok_server.domain.dex.bookmark.api.dto.response.BookmarkStatusResponse;
 import org.devkor.apu.saerok_server.domain.dex.bookmark.api.dto.response.BookmarkToggleResponse;
@@ -33,22 +32,6 @@ public interface BookmarkMapper {
 
     // List<UserBirdBookmark> -> List<BookmarkedBirdDetailResponse>
     List<BookmarkedBirdDetailResponse> toBookmarkedBirdDetailResponseList(List<UserBirdBookmark> bookmarks);
-
-    /**
-     * 조류 이미지 URL 목록을 추출합니다.
-     * @param images 조류 이미지 목록
-     * @return 이미지 URL 목록
-     */
-    @Named("extractImageUrls")
-    default List<String> extractImageUrls(List<BirdImage> images) {
-        if (images == null) {
-            return List.of();
-        }
-
-        return images.stream()
-                .map(BirdImage::getS3Url)
-                .toList();
-    }
 
     // 북마크 상태 응답 생성
     BookmarkStatusResponse toBookmarkStatusResponse(Long birdId, boolean bookmarked);

--- a/src/main/java/org/devkor/apu/saerok_server/global/util/ImageDomainService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/util/ImageDomainService.java
@@ -9,6 +9,9 @@ public class ImageDomainService {
     @Value("${aws.cloudfront.upload-image-domain}")
     private String uploadImageDomain;
 
+    @Value("${aws.cloudfront.dex-image-domain}")
+    private String dexImageDomain;
+
     /**
      * 사용자가 업로드한 이미지 전용 (컬렉션 이미지, 프로필 사진, ...) <br>
      * 현재 "도감 이미지"와 "사용자 업로드 이미지" 버킷을 나누어서 관리하고 있어서, toUploadImageUrl을 쓰면 "사용자 업로드 이미지 버킷"에 해당하는 CloudFront 도메인을 붙여줍니다.
@@ -18,5 +21,9 @@ public class ImageDomainService {
      */
     public String toUploadImageUrl(String objectKey) {
         return uploadImageDomain + "/" + objectKey;
+    }
+
+    public String toDexImageUrl(String objectKey) {
+        return dexImageDomain + "/" + objectKey;
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -42,8 +42,10 @@ aws:
   region: ap-northeast-2
   s3:
     upload-image-bucket: ${UPLOAD_IMAGE_BUCKET_NAME}
+    dex-image-bucket: ${DEX_IMAGE_BUCKET_NAME}
   cloudfront:
     upload-image-domain: ${UPLOAD_IMAGE_DOMAIN}
+    dex-image-domain: ${DEX_IMAGE_DOMAIN}
   kms:
     key-id: ${KMS_KEY_ID}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,8 +30,10 @@ aws:
   region: ap-northeast-2
   s3:
     upload-image-bucket: ${UPLOAD_IMAGE_BUCKET_NAME}
+    dex-image-bucket: ${DEX_IMAGE_BUCKET_NAME}
   cloudfront:
     upload-image-domain: ${UPLOAD_IMAGE_DOMAIN}
+    dex-image-domain: ${DEX_IMAGE_DOMAIN}
 #  kms:
 #    key-id:
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -45,8 +45,10 @@ aws:
   region: ap-northeast-2
   s3:
     upload-image-bucket: ${UPLOAD_IMAGE_BUCKET_NAME}
+    dex-image-bucket: ${DEX_IMAGE_BUCKET_NAME}
   cloudfront:
     upload-image-domain: ${UPLOAD_IMAGE_DOMAIN}
+    dex-image-domain: ${DEX_IMAGE_DOMAIN}
   kms:
     key-id: ${KMS_KEY_ID}
 

--- a/src/main/resources/db/migration/V23__add_object_key_to_bird_img.sql
+++ b/src/main/resources/db/migration/V23__add_object_key_to_bird_img.sql
@@ -1,0 +1,7 @@
+ALTER TABLE bird_image ADD COLUMN object_key TEXT;
+
+UPDATE bird_image
+    SET object_key = replace(s3_url, 'https://d30ecbxpvvxmvh.cloudfront.net/', '')
+    WHERE s3_url LIKE 'https://d30ecbxpvvxmvh.cloudfront.net/%';
+
+ALTER TABLE bird_image ALTER COLUMN object_key SET NOT NULL;

--- a/src/main/resources/db/migration/V24__replace_s3_url_with_object_key_in_bird_profile_mv.sql
+++ b/src/main/resources/db/migration/V24__replace_s3_url_with_object_key_in_bird_profile_mv.sql
@@ -1,0 +1,115 @@
+DROP MATERIALIZED VIEW IF EXISTS bird_profile_mv;
+
+CREATE MATERIALIZED VIEW bird_profile_mv AS
+WITH month_season AS (
+    SELECT m AS month,
+           CASE WHEN m IN (3,4,5)   THEN 'SPRING'
+                WHEN m IN (6,7,8)   THEN 'SUMMER'
+                WHEN m IN (9,10,11) THEN 'AUTUMN'
+                ELSE                    'WINTER'
+               END AS season
+    FROM generate_series(1,12) AS g(m)
+),
+     bird_month_priority AS (
+         SELECT br.bird_id,
+                ms.month,
+                MAX(rt.priority) AS priority
+         FROM bird_residency br
+                  JOIN rarity_type     rt  ON rt.id  = br.rarity_type_id
+                  JOIN residency_type  rty ON rty.id = br.residency_type_id
+                  JOIN month_season    ms  ON ((COALESCE(br.month_bitmask, rty.month_bitmask)
+             >> (ms.month-1)) & 1) = 1
+         GROUP BY br.bird_id, ms.month
+     ),
+     bird_season_priority AS (
+         SELECT bmp.bird_id,
+                ms.season,
+                MAX(bmp.priority) AS priority
+         FROM bird_month_priority bmp
+                  JOIN month_season ms ON ms.month = bmp.month
+         GROUP BY bmp.bird_id, ms.season
+     ),
+     bird_season_rarity AS (
+         SELECT bsp.bird_id,
+                bsp.season,
+                bsp.priority,
+                rt.code AS rarity_code
+         FROM bird_season_priority bsp
+                  JOIN rarity_type rt ON rt.priority = bsp.priority
+     ),
+     seasons_json AS (
+         SELECT bird_id,
+                jsonb_agg(
+                        jsonb_build_object(
+                                'season',   season,
+                                'rarity',   rarity_code,
+                                'priority', priority
+                        )
+                        ORDER BY array_position(
+                                ARRAY['SPRING','SUMMER','AUTUMN','WINTER'], season
+                                 )
+                ) AS seasons_with_rarity
+         FROM bird_season_rarity
+         GROUP BY bird_id
+     ),
+     habitats_array AS (
+         SELECT bird_id,
+                array_agg(DISTINCT habitat_type) AS habitats
+         FROM bird_habitat
+         GROUP BY bird_id
+     ),
+     images_json AS (
+         SELECT bird_id,
+                jsonb_agg(
+                        jsonb_build_object(
+                                'object_key',   object_key, -- s3_url을 object_key로 교체
+                                'original_url', original_url,
+                                'order_index',  order_index,
+                                'is_thumb',     is_thumb
+                        )
+                        ORDER BY order_index
+                ) AS images
+         FROM bird_image
+         GROUP BY bird_id
+     )
+SELECT
+    b.id,
+    b.korean_name,
+    b.scientific_name,
+    b.scientific_year,
+    b.description_is_ai_generated,
+    b.class_eng,
+    b.class_kor,
+    b."order_eng",
+    b."order_kor",
+    b.family_eng,
+    b.family_kor,
+    b.genus_eng,
+    b.genus_kor,
+    b.species_eng,
+    b.species_kor,
+    b.scientific_author,
+    b.phylum_eng,
+    b.phylum_kor,
+    b.nibr_url,
+    b.description,
+    b.description_source,
+    ha.habitats,
+    b.body_length_cm,
+    COALESCE(sj.seasons_with_rarity, '[]'::jsonb) AS seasons_with_rarity,
+    COALESCE(ij.images,              '[]'::jsonb) AS images,
+    b.created_at,
+    b.updated_at,
+    b.deleted_at
+FROM bird b
+         LEFT JOIN habitats_array ha ON ha.bird_id = b.id
+         LEFT JOIN seasons_json  sj ON sj.bird_id = b.id
+         LEFT JOIN images_json   ij ON ij.bird_id = b.id
+WHERE b.deleted_at IS NULL
+WITH NO DATA;
+
+-- MV에 고유 인덱스 생성 (Concurrent Refresh 요건)
+CREATE UNIQUE INDEX idx_bird_profile_mv_id ON bird_profile_mv(id);
+
+-- MV 초기 데이터 채우기 (Refresh)
+REFRESH MATERIALIZED VIEW bird_profile_mv;

--- a/src/main/resources/db/migration/V25__drop_s3_url_from_bird_img.sql
+++ b/src/main/resources/db/migration/V25__drop_s3_url_from_bird_img.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bird_image DROP COLUMN s3_url;


### PR DESCRIPTION
## 📝 요약(Summary)

차후 관리자가 운영 중인 서비스의 도감 이미지를 수정할 수 있게 될 가능성을 고려했을 때, 기존 개발 서버와 운영 서버가 동일한 S3 버킷을 참조하는 구조는 리스크가 있어 도감 이미지 버킷을 개발 서버용/운영 서버용으로 분리했습니다. 또한 기존에는 도감 이미지의 Full URL을 DB에 직접 저장하고 있었던 방식을 개선하여, object key만 저장하고 코드에서 도메인과 조합해 URL을 생성하는 방식으로 변경했습니다

![image](https://github.com/user-attachments/assets/4e318966-b285-4014-8470-9826f2c591a9)
![image](https://github.com/user-attachments/assets/9896f999-1e50-49ab-b3a1-d76f5805e771)

## 💬 공유사항

bird_image 테이블에서 s3_url 칼럼을 삭제하고 object_key 칼럼을 추가했어요

- 기존에는 s3_url(`https://abcdef.cloudfront.net/raw/12345-67890.jpg`)을 DB에 직접 저장하고 제공
- 이제는 object_key(`raw/12345-67890.jpg`)를 들고 있다가
  - 사용자에게 URL 제공 시: `ImageDomainService.toDexImageUrl(object_key)`로 실제 URL로 변환
  - (이전에 CloudFrontUrlService였던 거 이름을 ImageDomainService로 바꿨습니다)

이런 느낌

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.