### PR TITLE
docs: 선택적 인증 API를 swagger 문서에서 구분

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -367,7 +367,7 @@ public class CollectionController {
     @GetMapping("/nearby")
     @PermitAll
     @Operation(
-            summary = "주위의 컬렉션 조회",
+            summary = "주위의 컬렉션 조회 (인증: optional)",
             security = @SecurityRequirement(name = "bearerAuth"),
             description = """
                     주위의 컬렉션을 조회합니다.


### PR DESCRIPTION
## 📝 요약(Summary)

#92 를 반영합니다.

## 💬 공유사항

API를 인증 필요 여부에 따라 이렇게 볼 수 있어요
- 인증이 무조건 필요함
- 인증 전혀 필요없음 (API 작동할 때 로그인/비로그인 유저를 구분하는 로직이 없음)
- 선택적 인증 (`@PermitAll`로 비로그인 유저도 받아들이긴 하지만, 로그인/비로그인 유저를 구분하는 로직이 있음)

선택적 인증의 경우에는 지금 쓰고있는 `springdoc-openapi` 라이브러리를 이용한 swagger 문서화를 할 때 깔끔하게 해결할 수 있는 방법이 없는 것 같아요. 그래서 이런 선택적 인증 API의 경우는 #92 와 같이 다뤄야 할 것 같습니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.