### PR TITLE
refactor(coll): 컬렉션 조회 응답에 댓글 수 집계 추가

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -239,6 +239,7 @@ public class CollectionController {
             - imageUrl
             - koreanName
             - likeCount
+            - commentCount
 
             """,
             responses = {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionDetailResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionDetailResponse.java
@@ -38,7 +38,10 @@ public class GetCollectionDetailResponse {
     private AccessLevelType accessLevel;
 
     @Schema(description = "좋아요 수", example = "15")
-    private Integer likeCount;
+    private Long likeCount;
+
+    @Schema(description = "댓글 수", example = "7")
+    private Long commentCount;
 
     @Schema(description = "내가 좋아요 눌렀는지 여부", example = "true")
     private Boolean isLiked;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
@@ -42,7 +42,10 @@ public class GetNearbyCollectionsResponse {
         private String address;
 
         @Schema(description = "좋아요 수", example = "15")
-        private Integer likeCount;
+        private Long likeCount;
+
+        @Schema(description = "댓글 수", example = "7")
+        private Long commentCount;
 
         @Schema(description = "내가 좋아요 눌렀는지 여부", example = "true")
         private Boolean isLiked;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/MyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/MyCollectionsResponse.java
@@ -21,6 +21,9 @@ public record MyCollectionsResponse(
         String koreanName,
 
         @Schema(description = "좋아요 수", example = "15")
-        Integer likeCount
+        Long likeCount,
+
+        @Schema(description = "댓글 수", example = "7")
+        Long commentCount
     ) { }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -52,14 +52,16 @@ public interface CollectionWebMapper {
     @Mapping(target = "user.userId", source = "collection.user.id")
     @Mapping(target = "user.nickname", source = "collection.user.nickname")
     @Mapping(target = "likeCount", source = "likeCount")
+    @Mapping(target = "commentCount", source = "commentCount")
     @Mapping(target = "isLiked", source = "isLiked")
-    GetCollectionDetailResponse toGetCollectionDetailResponse(UserBirdCollection collection, String imageUrl, int likeCount, boolean isLiked);
+    GetCollectionDetailResponse toGetCollectionDetailResponse(UserBirdCollection collection, String imageUrl, long likeCount, long commentCount, boolean isLiked);
 
     @Mapping(target = "collectionId", source = "collection.id")
     @Mapping(target = "koreanName", source = "collection.bird.name.koreanName")
     @Mapping(target = "likeCount", source = "likeCount")
+    @Mapping(target = "commentCount", source = "commentCount")
     @Mapping(target = "isLiked", source = "isLiked")
-    GetNearbyCollectionsResponse.Item toGetNearbyCollectionsResponseItem(UserBirdCollection collection, String imageUrl, int likeCount, boolean isLiked);
+    GetNearbyCollectionsResponse.Item toGetNearbyCollectionsResponseItem(UserBirdCollection collection, String imageUrl, long likeCount, long commentCount, boolean isLiked);
 
     @Named("getBirdId")
     default Long getBirdId(UserBirdCollection collection) {

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryServiceTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryServiceTest.java
@@ -4,6 +4,7 @@ import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollec
 import org.devkor.apu.saerok_server.domain.collection.application.dto.GetNearbyCollectionsCommand;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
+import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionCommentRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionImageRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionLikeRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
@@ -40,6 +41,7 @@ class CollectionQueryServiceTest {
     @Mock CollectionRepository collectionRepository;
     @Mock CollectionImageRepository collectionImageRepository;
     @Mock CollectionLikeRepository collectionLikeRepository;
+    @Mock CollectionCommentRepository collectionCommentRepository;
     @Mock CollectionWebMapper collectionWebMapper;
     @Mock UserRepository userRepository;
     @Mock
@@ -55,6 +57,7 @@ class CollectionQueryServiceTest {
                 collectionRepository,
                 collectionImageRepository,
                 collectionLikeRepository,
+                collectionCommentRepository,
                 collectionWebMapper,
                 userRepository,
                 imageDomainService
@@ -91,8 +94,9 @@ class CollectionQueryServiceTest {
         given(collectionRepository.findById(collectionId)).willReturn(Optional.of(collection));
         given(collectionImageRepository.findObjectKeysByCollectionId(collectionId)).willReturn(List.of(objectKey));
         given(collectionLikeRepository.countByCollectionId(collectionId)).willReturn(5L);
+        given(collectionCommentRepository.countByCollectionId(collectionId)).willReturn(3L);
         given(imageDomainService.toUploadImageUrl(objectKey)).willReturn(imageUrl);
-        given(collectionWebMapper.toGetCollectionDetailResponse(collection, imageUrl, 5, false)).willReturn(expected);
+        given(collectionWebMapper.toGetCollectionDetailResponse(collection, imageUrl, 5L, 3L, false)).willReturn(expected);
 
         // when
         GetCollectionDetailResponse actual = collectionQueryService.getCollectionDetailResponse(null, collectionId);
@@ -121,9 +125,10 @@ class CollectionQueryServiceTest {
         given(collectionRepository.findById(collectionId)).willReturn(Optional.of(collection));
         given(collectionImageRepository.findObjectKeysByCollectionId(collectionId)).willReturn(List.of());
         given(collectionLikeRepository.countByCollectionId(collectionId)).willReturn(3L);
+        given(collectionCommentRepository.countByCollectionId(collectionId)).willReturn(2L);
         given(collectionLikeRepository.existsByUserIdAndCollectionId(userId, collectionId)).willReturn(true);
         GetCollectionDetailResponse expected = new GetCollectionDetailResponse();
-        given(collectionWebMapper.toGetCollectionDetailResponse(collection, null, 3, true)).willReturn(expected);
+        given(collectionWebMapper.toGetCollectionDetailResponse(collection, null, 3L, 2L, true)).willReturn(expected);
 
         // when
         GetCollectionDetailResponse actual =


### PR DESCRIPTION
## 📝 요약(Summary)

컬렉션 조회 응답에 댓글 수 필드를 포함시켰습니다.

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->

## 💬 공유사항

추가적으로, likeCount가 21억...을 넘을 것 같진 않아서 int로 했었던 것을 컨벤션에 따라 Long으로 일단 바꿨습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.