### PR TITLE
fix: countLikesByCommentIds 로직 에러 픽스

### DIFF
--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionCommentLikeRepositoryTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionCommentLikeRepositoryTest.java
@@ -1,0 +1,180 @@
+package org.devkor.apu.saerok_server.domain.collection.core.repository;
+
+import org.devkor.apu.saerok_server.domain.collection.core.entity.*;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.testsupport.AbstractPostgresContainerTest;
+import org.junit.jupiter.api.*;
+import org.locationtech.jts.geom.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import(CollectionCommentLikeRepository.class)
+@ActiveProfiles("test")
+class CollectionCommentLikeRepositoryTest extends AbstractPostgresContainerTest {
+
+    @Autowired CollectionCommentLikeRepository repo;
+    @Autowired TestEntityManager em;
+
+    private final GeometryFactory gf = new GeometryFactory();
+    private Field collUserField;
+
+    /* ------------------------------------------------------------------
+     * helpers
+     * ------------------------------------------------------------------ */
+    @BeforeEach
+    void setup() throws NoSuchFieldException {
+        collUserField = UserBirdCollection.class.getDeclaredField("user");
+        collUserField.setAccessible(true);
+    }
+
+    private User newUser() {
+        User u = new User();
+        em.persist(u);
+        return u;
+    }
+
+    private UserBirdCollection newCollection(User owner) {
+        try {
+            UserBirdCollection c = new UserBirdCollection();
+            collUserField.set(c, owner);
+
+            c.setAccessLevel(AccessLevelType.PUBLIC);
+            c.setDiscoveredDate(LocalDate.now());
+            Point p = gf.createPoint(new Coordinate(126.9780, 37.5665));
+            c.setLocation(p);
+
+            em.persist(c);
+            return c;
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private UserBirdCollectionComment newComment(User user, UserBirdCollection col, String content) {
+        UserBirdCollectionComment cm = UserBirdCollectionComment.of(user, col, content);
+        em.persist(cm);
+        return cm;
+    }
+
+    private UserBirdCollectionCommentLike newLike(User user, UserBirdCollectionComment cm) {
+        UserBirdCollectionCommentLike like = new UserBirdCollectionCommentLike(user, cm);
+        em.persist(like);
+        return like;
+    }
+
+    /* ------------------------------------------------------------------
+     * tests
+     * ------------------------------------------------------------------ */
+
+    @Test @DisplayName("save & findByUserIdAndCommentId")
+    void save_and_find() {
+        User u = newUser();
+        UserBirdCollection col = newCollection(u);
+        UserBirdCollectionComment cm = newComment(u, col, "hi");
+
+        UserBirdCollectionCommentLike like = new UserBirdCollectionCommentLike(u, cm);
+        repo.save(like);
+        em.flush(); em.clear();
+
+        Optional<UserBirdCollectionCommentLike> found =
+                repo.findByUserIdAndCommentId(u.getId(), cm.getId());
+
+        assertTrue(found.isPresent());
+        assertEquals(u.getId(), found.get().getUser().getId());
+        assertEquals(cm.getId(), found.get().getComment().getId());
+    }
+
+    @Test @DisplayName("existsByUserIdAndCommentId")
+    void exists() {
+        User u = newUser();
+        UserBirdCollection col = newCollection(u);
+        UserBirdCollectionComment cm = newComment(u, col, "hi");
+
+        assertFalse(repo.existsByUserIdAndCommentId(u.getId(), cm.getId()));
+
+        newLike(u, cm);
+        em.flush(); em.clear();
+
+        assertTrue(repo.existsByUserIdAndCommentId(u.getId(), cm.getId()));
+    }
+
+    @Test @DisplayName("remove")
+    void remove() {
+        User u = newUser();
+        UserBirdCollection col = newCollection(u);
+        UserBirdCollectionComment cm = newComment(u, col, "hi");
+
+        UserBirdCollectionCommentLike like = newLike(u, cm);
+        em.flush(); em.clear();
+
+        repo.remove(em.find(UserBirdCollectionCommentLike.class, like.getId()));
+        em.flush(); em.clear();
+
+        assertFalse(repo.existsByUserIdAndCommentId(u.getId(), cm.getId()));
+    }
+
+    @Test @DisplayName("countByCommentId")
+    void count_single() {
+        User u1 = newUser();
+        User u2 = newUser();
+        UserBirdCollection col = newCollection(u1);
+        UserBirdCollectionComment cm = newComment(u1, col, "hi");
+
+        newLike(u1, cm);
+        newLike(u2, cm);
+        em.flush(); em.clear();
+
+        assertEquals(2L, repo.countByCommentId(cm.getId()));
+    }
+
+    @Test @DisplayName("countLikesByCommentIds – 0 포함")
+    void count_batch_with_zeros() {
+        User u = newUser();
+        UserBirdCollection col = newCollection(u);
+
+        UserBirdCollectionComment cm1 = newComment(u, col, "A"); // 1 like
+        UserBirdCollectionComment cm2 = newComment(u, col, "B"); // 0 like
+        UserBirdCollectionComment cm3 = newComment(u, col, "C"); // 0 like
+
+        newLike(u, cm1);
+        em.flush(); em.clear();
+
+        Map<Long, Long> counts = repo.countLikesByCommentIds(
+                List.of(cm1.getId(), cm2.getId(), cm3.getId()));
+
+        assertEquals(1L, counts.get(cm1.getId()));
+        assertEquals(0L, counts.get(cm2.getId()));
+        assertEquals(0L, counts.get(cm3.getId()));
+    }
+
+    @Test @DisplayName("findLikeStatusByUserIdAndCommentIds")
+    void like_status_batch() {
+        User liker = newUser();
+        User other = newUser();
+        UserBirdCollection col = newCollection(liker);
+
+        UserBirdCollectionComment cm1 = newComment(other, col, "A");
+        UserBirdCollectionComment cm2 = newComment(other, col, "B");
+
+        newLike(liker, cm1);
+        em.flush(); em.clear();
+
+        Map<Long, Boolean> status = repo.findLikeStatusByUserIdAndCommentIds(
+                liker.getId(), List.of(cm1.getId(), cm2.getId()));
+
+        assertTrue(status.get(cm1.getId()));
+        assertFalse(status.get(cm2.getId()));
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

새록 댓글 목록 조회 API 호출 시, 좋아요가 0인 댓글이 포함되어 있을 경우 정상적으로 처리하지 못하는 버그를 수정했습니다.

새록 댓글의 좋아요 repository 테스트를 추가했습니다.

## 💬 공유사항

@pizzazoa 
트러블슈팅 로그 공유해요!

- 새록 댓글 목록 조회 중 서버 내부 오류 발생
  - `likeCounts에 댓글 ID 1이 없습니다` 오류 발생
  - <img width="1181" height="477" alt="image" src="https://github.com/user-attachments/assets/ba1e3ad6-e868-4e3c-84cb-88c6145f7d83" />
  - 외부에서 준 likeCounts가 비정상이라는 뜻
  - likeCounts를 준 것은 `countLikesByCommentIds`
  - <img width="708" height="56" alt="image" src="https://github.com/user-attachments/assets/c90c5ddc-f7fe-4d30-8538-f07453f4150d" />

  - <img width="721" height="161" alt="image" src="https://github.com/user-attachments/assets/0afcc053-553f-442b-92b0-a31c8bc4ad2c" />
  - 살펴 보니 기존 `countLikesByCommentIds` 구현이 잘못되었음 (좋아요가 없는 댓글일 경우 `results`에 아예 해당 댓글 id가 포함되지 않음)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.