### PR TITLE
feat(coll): 댓글 신고 기능 구현

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionCommentReportController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionCommentReportController.java
@@ -33,8 +33,7 @@ public class CollectionCommentReportController {
                             content = @Content(schema = @Schema(implementation = ReportCollectionCommentResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
                     @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
-                    @ApiResponse(responseCode = "404", description = "댓글 또는 컬렉션이 존재하지 않음", content = @Content),
-                    @ApiResponse(responseCode = "409", description = "이미 신고한 댓글", content = @Content)
+                    @ApiResponse(responseCode = "404", description = "댓글 또는 컬렉션이 존재하지 않음 (또는 이미 신고한 댓글)", content = @Content)
             }
     )
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionCommentReportController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionCommentReportController.java
@@ -1,0 +1,48 @@
+package org.devkor.apu.saerok_server.domain.collection.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.ReportCollectionCommentResponse;
+import org.devkor.apu.saerok_server.domain.collection.application.CollectionCommentReportCommandService;
+import org.devkor.apu.saerok_server.global.security.principal.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Collection Comment Report API", description = "컬렉션 댓글 신고 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("${api_prefix}/collections")
+public class CollectionCommentReportController {
+
+    private final CollectionCommentReportCommandService collectionCommentReportCommandService;
+
+    @PostMapping("/{collectionId}/comments/{commentId}/report")
+    @PreAuthorize("hasRole('USER')")
+    @Operation(
+            summary = "컬렉션 댓글 신고",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "신고 접수 성공",
+                            content = @Content(schema = @Schema(implementation = ReportCollectionCommentResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
+                    @ApiResponse(responseCode = "404", description = "댓글 또는 컬렉션이 존재하지 않음", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "이미 신고한 댓글", content = @Content)
+            }
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    public ReportCollectionCommentResponse reportComment(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long collectionId,
+            @PathVariable Long commentId
+    ) {
+        return collectionCommentReportCommandService.reportComment(userPrincipal.getId(), collectionId, commentId);
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/ReportCollectionCommentResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/ReportCollectionCommentResponse.java
@@ -1,0 +1,9 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReportCollectionCommentResponse(
+        @Schema(description = "신고 ID", example = "1")
+        Long reportId
+) {
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommentReportCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionCommentReportCommandService.java
@@ -1,0 +1,54 @@
+package org.devkor.apu.saerok_server.domain.collection.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.ReportCollectionCommentResponse;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionComment;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionCommentReport;
+import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionCommentRepository;
+import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionCommentReportRepository;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.devkor.apu.saerok_server.global.shared.exception.BadRequestException;
+import org.devkor.apu.saerok_server.global.shared.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CollectionCommentReportCommandService {
+
+    private final CollectionCommentReportRepository commentReportRepository;
+    private final CollectionCommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    public ReportCollectionCommentResponse reportComment(Long reporterId, Long collectionId, Long commentId) {
+
+        User reporter = userRepository.findById(reporterId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
+
+        UserBirdCollectionComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글 id예요"));
+
+        if (!comment.getCollection().getId().equals(collectionId)) {
+            throw new NotFoundException("해당 컬렉션에 속한 댓글이 아니에요");
+        }
+
+        if (comment.getUser().getId().equals(reporterId)) {
+            throw new BadRequestException("자신의 댓글은 신고할 수 없어요");
+        }
+
+        // 중복 신고 방지
+        boolean alreadyReported = commentReportRepository.existsByReporterIdAndCommentId(reporterId, commentId);
+        if (alreadyReported) {
+            throw new BadRequestException("이미 신고한 댓글이에요");
+        }
+
+        UserBirdCollectionCommentReport report = UserBirdCollectionCommentReport.of(reporter, comment.getUser(), comment);
+
+        commentReportRepository.save(report);
+        return new ReportCollectionCommentResponse(report.getId());
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/entity/UserBirdCollectionCommentReport.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/entity/UserBirdCollectionCommentReport.java
@@ -1,0 +1,43 @@
+package org.devkor.apu.saerok_server.domain.collection.core.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionComment;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.devkor.apu.saerok_server.global.shared.entity.CreatedAtOnly;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class UserBirdCollectionCommentReport extends CreatedAtOnly {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private User reportedUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private UserBirdCollectionComment comment;
+
+    @Column(name = "comment_content", nullable = false)
+    private String commentContent;
+
+    public static UserBirdCollectionCommentReport of(User reporter, User reportedUser, UserBirdCollectionComment comment) {
+        UserBirdCollectionCommentReport commentReport = new UserBirdCollectionCommentReport();
+        commentReport.reporter = reporter;
+        commentReport.reportedUser = reportedUser;
+        commentReport.comment = comment;
+        commentReport.commentContent = comment.getContent();
+        
+        return commentReport;
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionCommentReportRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/CollectionCommentReportRepository.java
@@ -1,0 +1,31 @@
+package org.devkor.apu.saerok_server.domain.collection.core.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionCommentReport;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CollectionCommentReportRepository {
+    
+    private final EntityManager em;
+    
+    public void save(UserBirdCollectionCommentReport report) { em.persist(report); }
+    
+    /**
+     * 특정 신고자가 특정 댓글을 이미 신고했는지 확인
+     * 중복 신고 방지용
+     */
+    public boolean existsByReporterIdAndCommentId(Long reporterId, Long commentId) {
+        return !em.createQuery(
+                "SELECT 1 FROM UserBirdCollectionCommentReport r " +
+                "WHERE r.reporter.id = :reporterId AND r.comment.id = :commentId",
+                Integer.class)
+                .setParameter("reporterId", reporterId)
+                .setParameter("commentId", commentId)
+                .setMaxResults(1)
+                .getResultList()
+                .isEmpty();
+    }
+}

--- a/src/main/resources/db/migration/V30__add_comment_report_table.sql
+++ b/src/main/resources/db/migration/V30__add_comment_report_table.sql
@@ -1,0 +1,17 @@
+CREATE SEQUENCE user_bird_collection_comment_report_seq START WITH 1 INCREMENT BY 50;
+
+-- 테이블 생성
+CREATE TABLE user_bird_collection_comment_report (
+    id               BIGINT       NOT NULL PRIMARY KEY,
+    reporter_id      BIGINT       NOT NULL,
+    reported_user_id BIGINT       NOT NULL,
+    comment_id       BIGINT       NOT NULL,
+    comment_content  TEXT         NOT NULL,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 외래키 제약조건 추가
+ALTER TABLE user_bird_collection_comment_report
+    ADD CONSTRAINT fk_user_bird_collection_comment_report_reporter FOREIGN KEY (reporter_id) REFERENCES users(id),
+    ADD CONSTRAINT fk_user_bird_collection_comment_report_reported_user FOREIGN KEY (reported_user_id) REFERENCES users(id),
+    ADD CONSTRAINT fk_user_bird_collection_comment_report_comment FOREIGN KEY (comment_id) REFERENCES user_bird_collection_comment(id) ON DELETE CASCADE;


### PR DESCRIPTION
## 📝 요약(Summary)

댓글 신고 기능을 구현했습니다.

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->

## 💬 공유사항

당장은 신고 사유를 받는다던가 하는 게 없어서 간단하게 구현했습니다.
댓글 id뿐만 아니라 댓글 내용까지 받는 이유는, 신고된 상태에서 수정하거나 하면 왜 신고가 들어왔는지 추적이 안될 수 있어서 로그 느낌..으로 필드를 추가했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.