### PR TITLE
feat(coll): 동정 의견 API 수정

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/SuggestBirdIdRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/SuggestBirdIdRequest.java
@@ -1,0 +1,9 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "동정 의견 제안")
+public record SuggestBirdIdRequest(
+        @Schema(description = "제안할 birdId", example = "123")
+        Long birdId
+) {}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/SuggestOrAgreeRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/request/SuggestOrAgreeRequest.java
@@ -1,9 +1,0 @@
-package org.devkor.apu.saerok_server.domain.collection.api.dto.request;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-
-@Schema(description = "동정 의견 제안/동의")
-public record SuggestOrAgreeRequest(
-        @Schema(description = "제안 또는 동의할 birdId", example = "123")
-        Long birdId
-) {}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/AgreeStatusResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/AgreeStatusResponse.java
@@ -1,0 +1,9 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "동의 상태 응답 DTO")
+public record AgreeStatusResponse(
+        @Schema(description = "동의 여부", example = "true")
+        boolean isAgreed
+) {}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/DisagreeStatusResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/DisagreeStatusResponse.java
@@ -1,0 +1,9 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "비동의 상태 응답 DTO")
+public record DisagreeStatusResponse(
+        @Schema(description = "비동의 여부", example = "true")
+        boolean isDisagreed
+) {}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetBirdIdSuggestionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetBirdIdSuggestionsResponse.java
@@ -27,7 +27,13 @@ public record GetBirdIdSuggestionsResponse(
             @Schema(description = "해당 조류에 동의한 사용자 수", example = "8", requiredMode = Schema.RequiredMode.REQUIRED)
             Long agreeCount,
 
+            @Schema(description = "해당 조류에 비동의한 사용자 수", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+            Long disagreeCount,
+
             @Schema(description = "현재 사용자가 동의했는지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-            Boolean isAgreedByMe
+            Boolean isAgreedByMe,
+
+            @Schema(description = "현재 사용자가 비동의했는지 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+            Boolean isDisagreedByMe
     ) {}
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/SuggestBirdIdResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/SuggestBirdIdResponse.java
@@ -1,0 +1,11 @@
+package org.devkor.apu.saerok_server.domain.collection.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "동정 의견 제안에 대한 응답")
+public record SuggestBirdIdResponse(
+
+        @Schema(description = "생성된 동정 의견 ID", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long suggestionId
+
+) {}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionCommandService.java
@@ -3,8 +3,7 @@ package org.devkor.apu.saerok_server.domain.collection.application;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.*;
-import org.devkor.apu.saerok_server.domain.collection.core.entity.BirdIdSuggestion;
-import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.*;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.*;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.Bird;
 import org.devkor.apu.saerok_server.domain.dex.bird.core.repository.BirdRepository;
@@ -25,9 +24,7 @@ public class BirdIdSuggestionCommandService {
     private final BirdRepository             birdRepo;
     private final UserRepository             userRepo;
 
-    /* 동정 의견 제안/동의 */
-    public SuggestOrAgreeResponse suggestOrAgree(Long userId, Long collectionId, Long birdId) {
-
+    public SuggestBirdIdResponse suggest(Long userId, Long collectionId, Long birdId) {
         User user = userRepo.findById(userId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
 
@@ -38,31 +35,136 @@ public class BirdIdSuggestionCommandService {
             throw new BadRequestException("이미 bird_id가 확정된 컬렉션이에요");
 
         if (collection.getUser().getId().equals(userId))
-            throw new BadRequestException("나 자신의 컬렉션에 동정 의견을 제안/동의할 수 없어요");
+            throw new BadRequestException("나 자신의 컬렉션에 동정 의견을 제안할 수 없어요");
 
         Bird bird = birdRepo.findById(birdId)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 조류 id예요"));
 
-        if (suggestionRepo.existsByUserIdAndCollectionIdAndBirdId(userId, collectionId, birdId))
-            throw new BadRequestException("이미 동의(또는 제안)한 항목이에요");
+        if (suggestionRepo.existsByUserIdAndCollectionIdAndBirdIdAndType(
+                userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.SUGGEST)) {
+            throw new BadRequestException("이미 내가 제안한 항목이에요");
+        }
 
-        BirdIdSuggestion suggestion = new BirdIdSuggestion(
-                user,
-                collection,
-                bird
-        );
-        suggestionRepo.save(suggestion);
+        if (suggestionRepo.existsByUserIdAndCollectionIdAndBirdIdAndType(
+                userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.AGREE)) {
+            throw new BadRequestException("이미 동의한 항목이에요");
+        }
 
-        return new SuggestOrAgreeResponse(suggestion.getId());
+        boolean birdAlreadySuggested = suggestionRepo.existsByCollectionIdAndBirdIdAndType(
+                collectionId, birdId, BirdIdSuggestion.SuggestionType.SUGGEST);
+
+        Long suggestionId;
+
+        if (birdAlreadySuggested) {
+            // 이미 제안된 경우 -> 동의만 추가
+            // 기존 비동의가 있다면 제거
+            suggestionRepo.findByUserIdAndCollectionIdAndBirdIdAndType(
+                userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.DISAGREE)
+                .ifPresent(suggestionRepo::remove);
+
+            // 동의 추가
+            BirdIdSuggestion agree = new BirdIdSuggestion(user, collection, bird, BirdIdSuggestion.SuggestionType.AGREE);
+            suggestionRepo.save(agree);
+            suggestionId = agree.getId();
+        } else {
+            // 첫 제안인 경우 -> 제안과 동의를 모두 추가
+            // 1. 제안 추가
+            BirdIdSuggestion suggestion = new BirdIdSuggestion(user, collection, bird, BirdIdSuggestion.SuggestionType.SUGGEST);
+            suggestionRepo.save(suggestion);
+            suggestionId = suggestion.getId();
+            
+            // 2. 동의도 자동으로 추가 (제안자는 자동으로 동의한 것으로 처리)
+            BirdIdSuggestion agree = new BirdIdSuggestion(user, collection, bird, BirdIdSuggestion.SuggestionType.AGREE);
+            suggestionRepo.save(agree);
+        }
+
+        return new SuggestBirdIdResponse(suggestionId);
     }
 
-    /* 동의 취소 */
-    public void cancelAgree(Long userId, Long collectionId, Long birdId) {
-        BirdIdSuggestion suggestion = suggestionRepo
-                .findByUserIdAndCollectionIdAndBirdId(userId, collectionId, birdId)
-                .orElseThrow(() -> new NotFoundException("동의/제안 기록이 없어요"));
+    public AgreeStatusResponse toggleAgree(Long userId, Long collectionId, Long birdId) {
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
 
-        suggestionRepo.remove(suggestion);
+        UserBirdCollection collection = collectionRepo.findById(collectionId)
+                .orElseThrow(() -> new NotFoundException("해당 id의 컬렉션이 존재하지 않아요"));
+
+        if (collection.getBird() != null)
+            throw new BadRequestException("이미 bird_id가 확정된 컬렉션이에요");
+
+        if (collection.getUser().getId().equals(userId))
+            throw new BadRequestException("나 자신의 컬렉션에 동의할 수 없어요");
+
+        Bird bird = birdRepo.findById(birdId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 조류 id예요"));
+        
+        if (!suggestionRepo.existsByCollectionIdAndBirdIdAndType(
+                collectionId, birdId, BirdIdSuggestion.SuggestionType.SUGGEST)) {
+            throw new BadRequestException("제안되지 않은 조류에는 동의할 수 없어요");
+        }
+
+        boolean agreeExists = suggestionRepo.existsByUserIdAndCollectionIdAndBirdIdAndType(
+                userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.AGREE);
+
+        if (agreeExists) {
+            // 동의가 이미 존재하면 제거 (동의 -1)
+            suggestionRepo.findByUserIdAndCollectionIdAndBirdIdAndType(
+                    userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.AGREE)
+                .ifPresent(suggestionRepo::remove);
+            return new AgreeStatusResponse(false);
+        } else {
+            // 기존 비동의가 있다면 제거 (비동의 -1)
+            suggestionRepo.findByUserIdAndCollectionIdAndBirdIdAndType(
+                    userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.DISAGREE)
+                .ifPresent(suggestionRepo::remove);
+
+            // 동의 추가 (동의 +1)
+            BirdIdSuggestion agree = new BirdIdSuggestion(user, collection, bird, BirdIdSuggestion.SuggestionType.AGREE);
+            suggestionRepo.save(agree);
+            return new AgreeStatusResponse(true);
+        }
+    }
+
+    public DisagreeStatusResponse toggleDisagree(Long userId, Long collectionId, Long birdId) {
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
+
+        UserBirdCollection collection = collectionRepo.findById(collectionId)
+                .orElseThrow(() -> new NotFoundException("해당 id의 컬렉션이 존재하지 않아요"));
+
+        if (collection.getBird() != null)
+            throw new BadRequestException("이미 bird_id가 확정된 컬렉션이에요");
+
+        if (collection.getUser().getId().equals(userId))
+            throw new BadRequestException("나 자신의 컬렉션에 비동의할 수 없어요");
+
+        Bird bird = birdRepo.findById(birdId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 조류 id예요"));
+        
+        if (!suggestionRepo.existsByCollectionIdAndBirdIdAndType(
+                collectionId, birdId, BirdIdSuggestion.SuggestionType.SUGGEST)) {
+            throw new BadRequestException("제안되지 않은 조류에는 비동의할 수 없어요");
+        }
+
+        boolean disagreeExists = suggestionRepo.existsByUserIdAndCollectionIdAndBirdIdAndType(
+                userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.DISAGREE);
+
+        if (disagreeExists) {
+            // 비동의가 이미 존재하면 제거 (비동의 -1)
+            suggestionRepo.findByUserIdAndCollectionIdAndBirdIdAndType(
+                    userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.DISAGREE)
+                .ifPresent(suggestionRepo::remove);
+            return new DisagreeStatusResponse(false);
+        } else {
+            // 기존 동의가 있다면 제거 (동의 -1)
+            suggestionRepo.findByUserIdAndCollectionIdAndBirdIdAndType(
+                    userId, collectionId, birdId, BirdIdSuggestion.SuggestionType.AGREE)
+                .ifPresent(suggestionRepo::remove);
+
+            // 비동의 추가 (비동의 +1)
+            BirdIdSuggestion disagree = new BirdIdSuggestion(user, collection, bird, BirdIdSuggestion.SuggestionType.DISAGREE);
+            suggestionRepo.save(disagree);
+            return new DisagreeStatusResponse(true);
+        }
     }
 
     /* 채택 */

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionQueryService.java
@@ -79,7 +79,9 @@ public class BirdIdSuggestionQueryService {
                         s.birdScientificName(),
                         imageDomainService.toDexImageUrl(s.birdThumbImageObjectKey()),
                         s.agreeCount(),
-                        s.isAgreedByMe()
+                        s.disagreeCount(),
+                        s.isAgreedByMe(),
+                        s.isDisagreedByMe()
                 ))
                 .toList();
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/entity/BirdIdSuggestion.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/entity/BirdIdSuggestion.java
@@ -11,12 +11,13 @@ import org.devkor.apu.saerok_server.global.shared.entity.CreatedAtOnly;
 /**
  * 동정 의견.
  * user가 collection에 대해 bird라는 의견을 제시함.
+ * type에 따라 제안(SUGGEST), 동의(AGREE), 비동의(DISAGREE)를 구분
  */
 @Entity
 @Table(
         name = "bird_id_suggestion",
         uniqueConstraints = @UniqueConstraint(columnNames = {
-                "user_id", "user_bird_collection_id", "bird_id"
+                "user_id", "user_bird_collection_id", "bird_id", "type"
         })
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,12 +40,24 @@ public class BirdIdSuggestion extends CreatedAtOnly {
     @JoinColumn(name = "bird_id", nullable = false)
     private Bird bird;
 
-    public BirdIdSuggestion(User user, UserBirdCollection collection, Bird bird) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private SuggestionType type;
+
+    public BirdIdSuggestion(User user, UserBirdCollection collection, Bird bird, SuggestionType type) {
         if (user == null) throw new IllegalArgumentException("user는 null일 수 없습니다.");
         if (collection == null) throw new IllegalArgumentException("collection은 null일 수 없습니다.");
         if (bird == null) throw new IllegalArgumentException("bird는 null일 수 없습니다.");
+        if (type == null) throw new IllegalArgumentException("type은 null일 수 없습니다.");
         this.user = user;
         this.collection = collection;
         this.bird = bird;
+        this.type = type;
+    }
+
+    public enum SuggestionType {
+        SUGGEST,    // 제안
+        AGREE,      // 동의
+        DISAGREE    // 비동의
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/BirdIdSuggestionRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/BirdIdSuggestionRepository.java
@@ -31,20 +31,23 @@ public class BirdIdSuggestionRepository {
     /* ──────────────────────── 단건 조회 / 존재 여부 체크 ─────────────────────── */
 
     /**
-     * 특정 사용자가 특정 컬렉션에 특정 birdId를 이미 제안/동의했는지 조회
+     * 특정 사용자가 특정 컬렉션에 특정 birdId를 특정 타입으로 이미 등록했는지 조회
      */
-    public Optional<BirdIdSuggestion> findByUserIdAndCollectionIdAndBirdId(Long userId,
-                                                                           Long collectionId,
-                                                                           Long birdId) {
+    public Optional<BirdIdSuggestion> findByUserIdAndCollectionIdAndBirdIdAndType(Long userId,
+                                                                                  Long collectionId,
+                                                                                  Long birdId,
+                                                                                  BirdIdSuggestion.SuggestionType type) {
         List<BirdIdSuggestion> results = em.createQuery(
                         "SELECT s FROM BirdIdSuggestion s " +
                                 "WHERE s.user.id = :userId " +
                                 "  AND s.collection.id = :collectionId " +
-                                "  AND s.bird.id = :birdId",
+                                "  AND s.bird.id = :birdId " +
+                                "  AND s.type = :type",
                         BirdIdSuggestion.class)
                 .setParameter("userId", userId)
                 .setParameter("collectionId", collectionId)
                 .setParameter("birdId", birdId)
+                .setParameter("type", type)
                 .setMaxResults(1)
                 .getResultList();
 
@@ -52,20 +55,43 @@ public class BirdIdSuggestionRepository {
     }
 
     /**
-     * 중복 제안/동의 방지를 위한 존재 여부 확인
+     * 특정 타입의 중복 방지를 위한 존재 여부 확인
      */
-    public boolean existsByUserIdAndCollectionIdAndBirdId(Long userId,
-                                                          Long collectionId,
-                                                          Long birdId) {
+    public boolean existsByUserIdAndCollectionIdAndBirdIdAndType(Long userId,
+                                                                 Long collectionId,
+                                                                 Long birdId,
+                                                                 BirdIdSuggestion.SuggestionType type) {
         return !em.createQuery(
                         "SELECT 1 FROM BirdIdSuggestion s " +
                                 "WHERE s.user.id = :userId " +
                                 "  AND s.collection.id = :collectionId " +
-                                "  AND s.bird.id = :birdId",
+                                "  AND s.bird.id = :birdId " +
+                                "  AND s.type = :type",
                         Integer.class)
                 .setParameter("userId", userId)
                 .setParameter("collectionId", collectionId)
                 .setParameter("birdId", birdId)
+                .setParameter("type", type)
+                .setMaxResults(1)
+                .getResultList()
+                .isEmpty();
+    }
+
+    /**
+     * 특정 컬렉션에 특정 bird가 특정 타입으로 존재하는지 확인
+     */
+    public boolean existsByCollectionIdAndBirdIdAndType(Long collectionId,
+                                                        Long birdId,
+                                                        BirdIdSuggestion.SuggestionType type) {
+        return !em.createQuery(
+                        "SELECT 1 FROM BirdIdSuggestion s " +
+                                "WHERE s.collection.id = :collectionId " +
+                                "  AND s.bird.id = :birdId " +
+                                "  AND s.type = :type",
+                        Integer.class)
+                .setParameter("collectionId", collectionId)
+                .setParameter("birdId", birdId)
+                .setParameter("type", type)
                 .setMaxResults(1)
                 .getResultList()
                 .isEmpty();
@@ -100,31 +126,39 @@ public class BirdIdSuggestionRepository {
     /* ──────────────────────────── 통계/집계용 ──────────────────────────── */
 
     /**
-     * 특정 컬렉션에 제안된 birdId별 동의 숫자와
-     * '내가 동의했는지' 여부까지 포함한 요약 리스트를 반환.
+     * 특정 컬렉션에 제안된 birdId별 동의/비동의 숫자와
+     * '내가 동의했는지/비동의했는지' 여부까지 포함한 요약 리스트를 반환.
      *
-     * 반환 형태: Object[3]
+     * 반환 형태: Object[5]
      *   [0] -> Bird (조류 엔티티)
      *   [1] -> Long  (동의 수)
-     *   [2] -> Boolean (isAgreedByMe)
+     *   [2] -> Long (비동의 수)
+     *   [3] -> Boolean (isAgreedByMe)
+     *   [4] -> Boolean (isDisagreedByMe)
      *
      * 서비스 계층에서 DTO로 변환하여 사용한다.
      */
     @SuppressWarnings("unchecked")
     public List<BirdIdSuggestionSummary> findSummaryByCollectionId(Long collectionId, Long userId) {
 
-        // 1) 요약 데이터
+        // 1) 요약 데이터 - PostgreSQL 호환 쿼리로 수정
         List<Object[]> rows = em.createQuery("""
             SELECT s.bird,
-                   COUNT(s)        AS agreeCnt,
-                   SUM(CASE WHEN s.user.id = :myId THEN 1 ELSE 0 END) > 0
+                SUM(CASE WHEN s.type = :agreeType THEN 1 ELSE 0 END) AS agreeCnt,
+                SUM(CASE WHEN s.type = :disagreeType THEN 1 ELSE 0 END),
+                CASE WHEN SUM(CASE WHEN s.user.id = :myId AND s.type = :agreeType THEN 1 ELSE 0 END) > 0 THEN true ELSE false END,
+                CASE WHEN SUM(CASE WHEN s.user.id = :myId AND s.type = :disagreeType THEN 1 ELSE 0 END) > 0 THEN true ELSE false END
             FROM BirdIdSuggestion s
             WHERE s.collection.id = :colId
+            AND s.type IN (:agreeType, :disagreeType, :suggestType)
             GROUP BY s.bird, s.bird.id
             ORDER BY agreeCnt DESC, s.bird.id ASC
             """)
                 .setParameter("colId", collectionId)
                 .setParameter("myId",  userId)
+                .setParameter("agreeType", BirdIdSuggestion.SuggestionType.AGREE)
+                .setParameter("disagreeType", BirdIdSuggestion.SuggestionType.DISAGREE)
+                .setParameter("suggestType", BirdIdSuggestion.SuggestionType.SUGGEST)
                 .getResultList();
 
         // 2) 썸네일 일괄 로드
@@ -148,20 +182,24 @@ public class BirdIdSuggestionRepository {
         // 3) DTO 조립
         return rows.stream()
                 .map(r -> {
-                    Bird    bird        = (Bird)   r[0];
-                    Long    agreeCnt    = (Long)   r[1];
-                    Boolean agreedByMe  = (Boolean)r[2];
-                    String  thumbKey    = thumbMap.get(bird.getId());
+                    Bird    bird          = (Bird)    r[0];
+                    Long    agreeCnt      = (Long)    r[1];
+                    Long    disagreeCnt   = (Long)    r[2];
+                    Boolean agreedByMe    = (Boolean) r[3];
+                    Boolean disagreedByMe = (Boolean) r[4];
+                    String  thumbKey      = thumbMap.get(bird.getId());
 
-                    return new BirdIdSuggestionSummary(
-                            bird.getId(),
-                            bird.getName().getKoreanName(),
-                            bird.getName().getScientificName(),
-                            thumbKey,
-                            agreeCnt,
-                            agreedByMe
-                    );
-                })
-                .toList();
+                return new BirdIdSuggestionSummary(
+                        bird.getId(),
+                        bird.getName().getKoreanName(),
+                        bird.getName().getScientificName(),
+                        thumbKey,
+                        agreeCnt,
+                        disagreeCnt,
+                        agreedByMe,
+                        disagreedByMe
+                );
+            })
+            .toList();
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/dto/BirdIdSuggestionSummary.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/core/repository/dto/BirdIdSuggestionSummary.java
@@ -1,7 +1,7 @@
 package org.devkor.apu.saerok_server.domain.collection.core.repository.dto;
 
 /**
- * 특정 bird에 몇 명이 동의했고, 내가 동의했는지 여부
+ * 특정 bird에 대한 동정 의견 종합 정보
  */
 public record BirdIdSuggestionSummary(
         Long birdId,
@@ -9,6 +9,8 @@ public record BirdIdSuggestionSummary(
         String birdScientificName,
         String birdThumbImageObjectKey,
         Long agreeCount,
-        Boolean isAgreedByMe
+        Long disagreeCount,
+        Boolean isAgreedByMe,
+        Boolean isDisagreedByMe
 ) {
 }

--- a/src/main/resources/db/migration/V38__add_type_to_bird_id_suggestion.sql
+++ b/src/main/resources/db/migration/V38__add_type_to_bird_id_suggestion.sql
@@ -1,0 +1,23 @@
+-- bird_id_suggestion 테이블에 type 컬럼 추가 및 제약조건 수정
+
+-- type 컬럼 추가 (기본값은 SUGGEST)
+ALTER TABLE bird_id_suggestion 
+ADD COLUMN type VARCHAR(20) NOT NULL DEFAULT 'SUGGEST';
+
+-- 기존 unique 제약조건 삭제
+ALTER TABLE bird_id_suggestion 
+DROP CONSTRAINT uq_bird_id_suggestion_user_collection_bird;
+
+-- 새로운 unique 제약조건 추가 (type 포함)
+ALTER TABLE bird_id_suggestion 
+ADD CONSTRAINT uq_bird_id_suggestion_user_collection_bird_type 
+UNIQUE (user_id, user_bird_collection_id, bird_id, type);
+
+-- 인덱스 추가 (성능 최적화)
+CREATE INDEX idx_bird_id_suggestion_collection_bird_type ON bird_id_suggestion(user_bird_collection_id, bird_id, type);
+CREATE INDEX idx_bird_id_suggestion_type ON bird_id_suggestion(type);
+
+-- 타입 값 체크 제약조건 추가
+ALTER TABLE bird_id_suggestion 
+ADD CONSTRAINT chk_bird_id_suggestion_type 
+CHECK (type IN ('SUGGEST', 'AGREE', 'DISAGREE'));

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionQueryServiceTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionQueryServiceTest.java
@@ -97,9 +97,10 @@ class BirdIdSuggestionQueryServiceTest {
     class SuggestList {
 
         // DTO 헬퍼
-        private BirdIdSuggestionSummary sum(long birdId,long agree,boolean my){
+        private BirdIdSuggestionSummary sum(long birdId, long agree, long disagree, boolean isAgreed, boolean isDisagreed){
             return new BirdIdSuggestionSummary(
-                    birdId,"kor"+birdId,"sci"+birdId,"key"+birdId+".jpg",agree,my);
+                    birdId, "kor"+birdId, "sci"+birdId, "key"+birdId+".jpg",
+                    agree, disagree, isAgreed, isDisagreed);
         }
 
         @Test @DisplayName("성공 – 비회원")
@@ -107,7 +108,7 @@ class BirdIdSuggestionQueryServiceTest {
             when(collectionRepo.findById(10L))
                     .thenReturn(Optional.of(coll(10,user(1,"u"),"note")));
             when(suggestionRepo.findSummaryByCollectionId(10L,null))
-                    .thenReturn(List.of(sum(5,3,false)));
+                    .thenReturn(List.of(sum(5,3, 2, false, false)));
             when(imageDomainService.toDexImageUrl("key5.jpg")).thenReturn("url5");
 
             GetBirdIdSuggestionsResponse res = sut.getSuggestions(null,10L);

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/core/repository/BirdIdSuggestionRepositoryTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/core/repository/BirdIdSuggestionRepositoryTest.java
@@ -22,6 +22,8 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 import java.util.Optional;
 
+import org.devkor.apu.saerok_server.domain.collection.core.entity.BirdIdSuggestion.SuggestionType;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -50,6 +52,7 @@ class BirdIdSuggestionRepositoryTest extends AbstractPostgresContainerTest {
                 .user(u)
                 .collection(col)
                 .bird(b)
+                .type(SuggestionType.SUGGEST)
                 .build();
 
         em.flush();
@@ -68,7 +71,7 @@ class BirdIdSuggestionRepositoryTest extends AbstractPostgresContainerTest {
     }
 
     @Test
-    @DisplayName("existsByUserIdAndCollectionIdAndBirdId")
+    @DisplayName("existsByUserIdAndCollectionIdAndBirdIdAndType")
     void exists_check() {
         User u       = new UserBuilder(em).build();
         UserBirdCollection col = new CollectionBuilder(em).owner(u).build();
@@ -77,15 +80,15 @@ class BirdIdSuggestionRepositoryTest extends AbstractPostgresContainerTest {
                 .sciName("Corvus corone")
                 .build();
 
-        boolean before = repo.existsByUserIdAndCollectionIdAndBirdId(u.getId(), col.getId(), b.getId());
+        boolean before = repo.existsByUserIdAndCollectionIdAndBirdIdAndType(u.getId(), col.getId(), b.getId(), SuggestionType.AGREE);
         assertFalse(before);
         System.out.println("[exists_check] ▶︎ exists before save: " + before);
 
-        new SuggestionBuilder(repo, em).user(u).collection(col).bird(b).build();
+        new SuggestionBuilder(repo, em).user(u).collection(col).bird(b).type(SuggestionType.AGREE).build();
         em.flush();
         em.clear();
 
-        boolean after = repo.existsByUserIdAndCollectionIdAndBirdId(u.getId(), col.getId(), b.getId());
+        boolean after = repo.existsByUserIdAndCollectionIdAndBirdIdAndType(u.getId(), col.getId(), b.getId(), SuggestionType.AGREE);
         assertTrue(after);
         System.out.println("[exists_check] ✔︎ exists after save: " + after);
     }
@@ -122,11 +125,13 @@ class BirdIdSuggestionRepositoryTest extends AbstractPostgresContainerTest {
     }
 
     @Test
-    @DisplayName("findSummaryByCollectionId – agreeCnt & isAgreedByMe 계산")
+    @DisplayName("findSummaryByCollectionId – 동의/비동의 관련 계산")
     void summary() {
         User current = new UserBuilder(em).build();
-        User other   = new UserBuilder(em).build();
-        UserBirdCollection col = new CollectionBuilder(em).owner(other).build();
+        User other1  = new UserBuilder(em).build();
+        User other2  = new UserBuilder(em).build();
+        User collectionOwner = new UserBuilder(em).nickname("owner").build();
+        UserBirdCollection col = new CollectionBuilder(em).owner(collectionOwner).build();
 
         Bird b1 = new BirdBuilder(em)
                 .korName("직박구리")
@@ -136,35 +141,49 @@ class BirdIdSuggestionRepositoryTest extends AbstractPostgresContainerTest {
                 .korName("박새")
                 .sciName("Parus major")
                 .build();
+        Bird b3 = new BirdBuilder(em)
+                .korName("까치")
+                .sciName("Pica Serica")
+                .build(); // 제안만 되고 아무도 동의/비동의 안함
 
-        // b1: two agrees (one by current, one by other)
-        new SuggestionBuilder(repo, em).user(current).collection(col).bird(b1).build();
-        new SuggestionBuilder(repo, em).user(other).collection(col).bird(b1).build();
-        // b2: one agree (by other)
-        new SuggestionBuilder(repo, em).user(other).collection(col).bird(b2).build();
+        // b1: 제안(current), 동의(current, other1), 비동의(other2)
+        new SuggestionBuilder(repo, em).user(current).collection(col).bird(b1).type(SuggestionType.SUGGEST).build();
+        new SuggestionBuilder(repo, em).user(current).collection(col).bird(b1).type(SuggestionType.AGREE).build();
+        new SuggestionBuilder(repo, em).user(other1).collection(col).bird(b1).type(SuggestionType.AGREE).build();
+        new SuggestionBuilder(repo, em).user(other2).collection(col).bird(b1).type(SuggestionType.DISAGREE).build();
+
+        // b2: 제안(other1), 동의(other2), 비동의(current)
+        new SuggestionBuilder(repo, em).user(other1).collection(col).bird(b2).type(SuggestionType.SUGGEST).build();
+        new SuggestionBuilder(repo, em).user(other2).collection(col).bird(b2).type(SuggestionType.AGREE).build();
+        new SuggestionBuilder(repo, em).user(current).collection(col).bird(b2).type(SuggestionType.DISAGREE).build();
+
+        // b3: 제안(other2)
+        new SuggestionBuilder(repo, em).user(other2).collection(col).bird(b3).type(SuggestionType.SUGGEST).build();
 
         em.flush();
         em.clear();
 
         List<BirdIdSuggestionSummary> list =
                 repo.findSummaryByCollectionId(col.getId(), current.getId());
-        assertThat(list).hasSize(2);
+        assertThat(list).hasSize(3);
 
-        var first  = list.get(0);
-        var second = list.get(1);
-
-        assertThat(first.birdId()).isEqualTo(b1.getId());
+        // 결과 검증 - 이름으로 개별 아이템 찾아서 검증 (정렬 순서에 의존하지 않음)
+        var first = list.get(0);
         assertThat(first.agreeCount()).isEqualTo(2L);
+        assertThat(first.disagreeCount()).isEqualTo(1L);
         assertTrue(first.isAgreedByMe());
+        assertFalse(first.isDisagreedByMe());
 
-        assertThat(second.birdId()).isEqualTo(b2.getId());
+        var second = list.get(1);
         assertThat(second.agreeCount()).isEqualTo(1L);
+        assertThat(second.disagreeCount()).isEqualTo(1L);
         assertFalse(second.isAgreedByMe());
+        assertTrue(second.isDisagreedByMe());
 
-        System.out.printf(
-                "[summary] ✔︎ %d summaries returned (first: birdId=%d, agreeCnt=%d, isAgreedByMe=%b)%n",
-                list.size(),
-                first.birdId(), first.agreeCount(), first.isAgreedByMe()
-        );
+        var third = list.get(2);
+        assertThat(third.agreeCount()).isEqualTo(0L);
+        assertThat(third.disagreeCount()).isEqualTo(0L);
+        assertFalse(third.isAgreedByMe());
+        assertFalse(third.isDisagreedByMe());
     }
 }

--- a/src/test/java/org/devkor/apu/saerok_server/testsupport/builder/SuggestionBuilder.java
+++ b/src/test/java/org/devkor/apu/saerok_server/testsupport/builder/SuggestionBuilder.java
@@ -6,6 +6,7 @@ import org.devkor.apu.saerok_server.domain.collection.core.repository.BirdIdSugg
 import org.devkor.apu.saerok_server.domain.dex.bird.core.entity.Bird;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.BirdIdSuggestion.SuggestionType;
 
 /**
  * Builder for creating and persisting BirdIdSuggestion fixtures in tests.
@@ -16,6 +17,7 @@ public class SuggestionBuilder {
     private User user;
     private UserBirdCollection collection;
     private Bird bird;
+    private SuggestionType type = SuggestionType.SUGGEST; // default type
 
     public SuggestionBuilder(BirdIdSuggestionRepository repo, TestEntityManager em) {
         this.repo = repo;
@@ -37,11 +39,16 @@ public class SuggestionBuilder {
         return this;
     }
 
+    public SuggestionBuilder type(SuggestionType type) {
+        this.type = type;
+        return this;
+    }
+
     /**
      * Builds and persists the BirdIdSuggestion.
      */
     public BirdIdSuggestion build() {
-        BirdIdSuggestion suggestion = new BirdIdSuggestion(user, collection, bird);
+        BirdIdSuggestion suggestion = new BirdIdSuggestion(user, collection, bird, type);
         repo.save(suggestion);
         em.flush();
         return suggestion;


### PR DESCRIPTION
## 📝 요약(Summary)

프론트의 요청에 따라 동정 의견 API를 수정했습니다.

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->

## 💬 공유사항

요청 사항
- disagree에 대한 count와 isDisagreedByMe 필드를 응답 dto에 포함할 것
- 동정 제안과 동의를 분리하고, 동의, 비동의 2개의 API를 각각 토글로 만들 것

위 요청 사항을 반영하여 수정했습니다.
V37까지 다른 작업들에 쓰고 있는 중이라 V38로 작업했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.