### PR TITLE
fix: 회원 정보 수정 API 응답에서 프사 URL 제대로 표시 안 하는 문제 수정

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserCommandService.java
@@ -6,12 +6,12 @@ import org.devkor.apu.saerok_server.domain.user.api.dto.response.UpdateUserProfi
 import org.devkor.apu.saerok_server.domain.user.application.dto.UpdateUserProfileCommand;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.devkor.apu.saerok_server.domain.user.core.service.UserProfileImageUrlService;
 import org.devkor.apu.saerok_server.domain.user.core.service.UserProfileUpdateService;
 import org.devkor.apu.saerok_server.domain.user.core.service.UserSignupStatusService;
 import org.devkor.apu.saerok_server.global.shared.exception.BadRequestException;
 import org.devkor.apu.saerok_server.global.shared.exception.NotFoundException;
 import org.devkor.apu.saerok_server.global.shared.infra.ImageService;
-import org.devkor.apu.saerok_server.global.shared.infra.ImageDomainService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,8 +25,8 @@ public class UserCommandService {
     private final UserRepository userRepository;
     private final UserProfileUpdateService userProfileUpdateService;
     private final UserSignupStatusService userSignupStatusService;
-    private final ImageDomainService imageDomainService;
     private final ImageService imageService;
+    private final UserProfileImageUrlService userProfileImageUrlService;
 
     public UpdateUserProfileResponse updateUserProfile(UpdateUserProfileCommand command) {
 
@@ -40,6 +40,8 @@ public class UserCommandService {
 
         if (command.profileImageContentType() != null && command.profileImageObjectKey() != null) {
             userProfileUpdateService.changeProfileImage(user, command.profileImageObjectKey(), command.profileImageContentType());
+        } else if (!(command.profileImageContentType() == null && command.profileImageObjectKey() == null)) {
+            throw new BadRequestException("프로필 사진 변경 시, profileImageContentType과 profileImageObjectKey 둘 다 있어야 합니다");
         }
 
         userSignupStatusService.tryCompleteSignup(user);
@@ -47,7 +49,7 @@ public class UserCommandService {
         return new UpdateUserProfileResponse(
                 user.getNickname(),
                 user.getEmail(),
-                imageDomainService.toUploadImageUrl(command.profileImageObjectKey())
+                userProfileImageUrlService.getProfileImageUrlFor(user)
         );
     }
 


### PR DESCRIPTION
## 📝 요약(Summary)

사용자가 요청에 넣은 값(objectKey)을 그대로 써서 프사 URL 값으로 돌려주는 것에서, 실제 프사 URL 값을 찾아서 보여주도록 수정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.