### PR TITLE
feat: 회원 탈퇴 API 구현

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2.yml
+++ b/.github/workflows/deploy-to-dev-ec2.yml
@@ -75,6 +75,7 @@ jobs:
             APPLE_KEY_ID="${{ secrets.APPLE_KEY_ID }}" \
             APPLE_PRIVATE_KEY="${{ secrets.APPLE_PRIVATE_KEY }}" \
             JWT_SECRET="${{ secrets.JWT_SECRET }}" \
+            KAKAO_ADMIN_KEY="${{ secrets.KAKAO_ADMIN_KEY }}" \
             KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \
             KAKAO_REDIRECT_URI="${{ secrets.KAKAO_REDIRECT_URI }}" \
             KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \

--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -75,6 +75,7 @@ jobs:
             APPLE_KEY_ID="${{ secrets.APPLE_KEY_ID }}" \
             APPLE_PRIVATE_KEY="${{ secrets.APPLE_PRIVATE_KEY }}" \
             JWT_SECRET="${{ secrets.JWT_SECRET }}" \
+            KAKAO_ADMIN_KEY="${{ secrets.KAKAO_ADMIN_KEY }}" \
             KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \
             KAKAO_REDIRECT_URI="${{ secrets.KAKAO_REDIRECT_URI }}" \
             KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/AbstractSocialAuthService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/AbstractSocialAuthService.java
@@ -6,12 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.devkor.apu.saerok_server.domain.auth.api.dto.response.AccessTokenResponse;
 import org.devkor.apu.saerok_server.domain.auth.application.facade.AuthTokenFacade;
 import org.devkor.apu.saerok_server.domain.auth.application.facade.AuthTokenFacade.AuthBundle;
+import org.devkor.apu.saerok_server.domain.auth.core.dto.SocialUserInfo;
 import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialAuth;
 import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
 import org.devkor.apu.saerok_server.domain.auth.core.repository.SocialAuthRepository;
 import org.devkor.apu.saerok_server.domain.auth.core.service.UserProvisioningService;
 import org.devkor.apu.saerok_server.domain.auth.infra.SocialAuthClient;
-import org.devkor.apu.saerok_server.domain.auth.core.dto.SocialUserInfo;
+import org.devkor.apu.saerok_server.domain.user.core.entity.SignupStatusType;
 import org.devkor.apu.saerok_server.global.security.crypto.DataCryptoService;
 import org.devkor.apu.saerok_server.global.security.crypto.EncryptedPayload;
 import org.devkor.apu.saerok_server.global.shared.util.dto.ClientInfo;
@@ -40,6 +41,13 @@ public abstract class AbstractSocialAuthService {
 
         SocialAuth socialAuth = socialAuthRepository
                 .findByProviderAndProviderUserId(provider, userInfo.sub())
+                .map(link -> {
+                    // 탈퇴했던 유저면 재프로비저닝
+                    if (link.getUser().getSignupStatus() == SignupStatusType.WITHDRAWN) {
+                        userProvisioningService.provisionRejoinedUser(link, userInfo);
+                    }
+                    return link;
+                })
                 .orElseGet(() -> userProvisioningService.provisionNewUser(provider, userInfo));
 
         if (userInfo.refreshToken() != null) {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/SocialAuthRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/SocialAuthRepository.java
@@ -6,6 +6,7 @@ import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialAuth;
 import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -26,5 +27,12 @@ public class SocialAuthRepository {
     public SocialAuth save(SocialAuth socialAuth) {
         em.persist(socialAuth);
         return socialAuth;
+    }
+
+    public List<SocialAuth> findByUserId(Long userId) {
+        return em.createQuery(
+                "SELECT s FROM SocialAuth s WHERE s.user.id = :userId", SocialAuth.class)
+                .setParameter("userId", userId)
+                .getResultList();
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/SocialAuthRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/SocialAuthRepository.java
@@ -35,4 +35,10 @@ public class SocialAuthRepository {
                 .setParameter("userId", userId)
                 .getResultList();
     }
+
+    public void deleteByUserId(Long userId) {
+        em.createQuery("DELETE FROM SocialAuth s WHERE s.user.id = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/SocialAuthRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/SocialAuthRepository.java
@@ -35,10 +35,4 @@ public class SocialAuthRepository {
                 .setParameter("userId", userId)
                 .getResultList();
     }
-
-    public void deleteByUserId(Long userId) {
-        em.createQuery("DELETE FROM SocialAuth s WHERE s.user.id = :userId")
-                .setParameter("userId", userId)
-                .executeUpdate();
-    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/UserRefreshTokenRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/UserRefreshTokenRepository.java
@@ -23,4 +23,10 @@ public class UserRefreshTokenRepository {
                 .getResultStream()
                 .findFirst();
     }
+
+    public void deleteByUserId(Long userId) {
+        em.createQuery("DELETE FROM UserRefreshToken rt WHERE rt.user.id = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/UserRefreshTokenRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/repository/UserRefreshTokenRepository.java
@@ -24,8 +24,8 @@ public class UserRefreshTokenRepository {
                 .findFirst();
     }
 
-    public void deleteByUserId(Long userId) {
-        em.createQuery("DELETE FROM UserRefreshToken rt WHERE rt.user.id = :userId")
+    public int deleteByUserId(Long userId) {
+        return em.createQuery("DELETE FROM UserRefreshToken rt WHERE rt.user.id = :userId")
                 .setParameter("userId", userId)
                 .executeUpdate();
     }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/service/UserProvisioningService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/core/service/UserProvisioningService.java
@@ -15,10 +15,6 @@ import org.devkor.apu.saerok_server.domain.user.core.service.ProfileImageDefault
 import org.devkor.apu.saerok_server.global.shared.exception.SocialAuthAlreadyExistsException;
 import org.springframework.stereotype.Service;
 
-/**
- * 새로운 유저에 대한 프로비저닝(Provisioning: 사용자가 요청한 IT 자원을 사용할 수 있는 상태로 준비하는 것)을 담당하는 도메인 서비스
- * 사용자 관점에서는 "회원가입", 시스템 관점에서는 "프로비저닝".
- */
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -49,5 +45,33 @@ public class UserProvisioningService {
         return socialAuthRepository.save(
                 SocialAuth.createSocialAuth(user, provider, userInfo.sub())
         );
+    }
+
+    /**
+     * 탈퇴했던 사용자가 재가입할 때 필요한 자원을 다시 준비한다.
+     * 기존 users 레코드를 그대로 사용하고, 다음을 수행한다:
+     *  - signupStatus → PROFILE_REQUIRED
+     *  - deleted_at → null
+     *  - joined_at → 현재 시각
+     *  - 이메일이 비어 있으면 소셜에서 받은 이메일로 복구
+     *  - USER 롤이 없으면 다시 부여
+     *  - 기본 프로필 이미지가 비어 있으면 랜덤 배정
+     */
+    public void provisionRejoinedUser(SocialAuth existingLink, SocialUserInfo userInfo) {
+        User user = existingLink.getUser();
+
+        user.restoreForRejoin();
+
+        if (user.getEmail() == null && userInfo.email() != null) {
+            user.setEmail(userInfo.email());
+        }
+
+        if (userRoleRepository.findByUser(user).isEmpty()) {
+            userRoleRepository.save(UserRole.createUserRole(user, UserRoleType.USER));
+        }
+
+        if (user.getDefaultProfileImageVariant() == null) {
+            profileImageDefaultService.setRandomVariant(user);
+        }
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/AppleApiClient.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/AppleApiClient.java
@@ -72,6 +72,24 @@ public class AppleApiClient {
         return response;
     }
 
+    public void revokeRefreshToken(String refreshToken) {
+        String clientSecret = createClientSecret();
+        webClient.post()
+                .uri("https://appleid.apple.com/auth/revoke")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(BodyInserters.fromFormData("client_id", appleProperties.getClientId())
+                        .with("client_secret", clientSecret)
+                        .with("token", refreshToken)
+                        .with("token_type_hint", "refresh_token"))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response -> {
+                    log.error("Apple revoke 실패");
+                    return Mono.error(new OAuthException("Apple revoke 실패", 502));
+                })
+                .toBodilessEntity()
+                .block();
+    }
+
     private String createClientSecret() {
 
         Instant now = Instant.now();

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/AppleRevoker.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/AppleRevoker.java
@@ -1,0 +1,42 @@
+package org.devkor.apu.saerok_server.domain.auth.infra;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialAuth;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
+import org.devkor.apu.saerok_server.global.security.crypto.DataCryptoService;
+import org.devkor.apu.saerok_server.global.security.crypto.EncryptedPayload;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleRevoker implements SocialRevoker {
+
+    private final AppleApiClient appleApiClient;
+    private final DataCryptoService dataCryptoService;
+
+    @Override
+    public SocialProviderType provider() { return SocialProviderType.APPLE; }
+
+    @Override
+    public void revoke(SocialAuth link) {
+        if (link.getRefreshToken() == null || link.getRefreshToken().getCiphertext() == null) {
+            log.warn("[Apple] refresh token 없음: userId={}, providerUserId={}",
+                    link.getUser().getId(), link.getProviderUserId());
+            return; // 이미 없는 상태로 간주 (idempotent)
+        }
+        EncryptedPayload encryptedPayload = new EncryptedPayload(
+                link.getRefreshToken().getCiphertext(),
+                link.getRefreshToken().getKey(),
+                link.getRefreshToken().getIv(),
+                link.getRefreshToken().getTag()
+        );
+        byte[] refreshTokenBytes = dataCryptoService.decrypt(encryptedPayload);
+        String refreshToken = new String(refreshTokenBytes, StandardCharsets.UTF_8);
+        appleApiClient.revokeRefreshToken(refreshToken);
+        log.info("[Apple] revoke 완료: userId={}, providerUserId={}", link.getUser().getId(), link.getProviderUserId());
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoAdminApiClient.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoAdminApiClient.java
@@ -1,0 +1,39 @@
+package org.devkor.apu.saerok_server.domain.auth.infra;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.devkor.apu.saerok_server.global.shared.exception.OAuthException;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * Kakao Admin API 전용 클라이언트.
+ *
+ * <p>⚠️ Admin Key는 초권한이므로 일반 사용자 토큰 경로(KakaoApiClient)와 분리한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoAdminApiClient {
+
+    private final WebClient webClient;
+
+    public void unlinkUser(String adminKey, String providerUserId) {
+        webClient.post()
+                .uri("https://kapi.kakao.com/v1/user/unlink")
+                .header("Authorization", "KakaoAK " + adminKey)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(BodyInserters.fromFormData("target_id_type", "user_id")
+                        .with("target_id", providerUserId))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, resp -> {
+                    log.error("Kakao unlink 실패: providerUserId={}", providerUserId);
+                    return Mono.error(new OAuthException("Kakao unlink 실패", 502));
+                })
+                .toBodilessEntity()
+                .block();
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoRevoker.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoRevoker.java
@@ -1,0 +1,27 @@
+package org.devkor.apu.saerok_server.domain.auth.infra;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialAuth;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
+import org.devkor.apu.saerok_server.global.core.properties.KakaoProperties;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoRevoker implements SocialRevoker {
+
+    private final KakaoAdminApiClient kakaoAdminApiClient;
+    private final KakaoProperties kakaoProperties;
+
+    @Override
+    public SocialProviderType provider() { return SocialProviderType.KAKAO; }
+
+    @Override
+    public void revoke(SocialAuth link) {
+        String providerUserId = link.getProviderUserId();
+        kakaoAdminApiClient.unlinkUser(kakaoProperties.getAdminKey(), providerUserId);
+        log.info("[Kakao] unlink 완료: userId={}, providerUserId={}", link.getUser().getId(), providerUserId);
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/SocialRevoker.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/SocialRevoker.java
@@ -1,9 +1,9 @@
 package org.devkor.apu.saerok_server.domain.auth.infra;
 
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialAuth;
 import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
 
 public interface SocialRevoker {
-
     SocialProviderType provider();
-    void revoke(String accessToken);
+    void revoke(SocialAuth link);
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/SocialRevoker.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/SocialRevoker.java
@@ -1,0 +1,9 @@
+package org.devkor.apu.saerok_server.domain.auth.infra;
+
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
+
+public interface SocialRevoker {
+
+    SocialProviderType provider();
+    void revoke(String accessToken);
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bookmark/core/repository/BookmarkRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bookmark/core/repository/BookmarkRepository.java
@@ -84,4 +84,12 @@ public class BookmarkRepository {
     public void remove(UserBirdBookmark bookmark) {
         em.remove(bookmark);
     }
+
+    public void deleteByUserId(Long userId) {
+        em.createQuery(
+                        "DELETE FROM UserBirdBookmark b WHERE b.user.id = :userId"
+                )
+                .setParameter("userId", userId)
+                .executeUpdate();
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bookmark/core/repository/BookmarkRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bookmark/core/repository/BookmarkRepository.java
@@ -85,8 +85,8 @@ public class BookmarkRepository {
         em.remove(bookmark);
     }
 
-    public void deleteByUserId(Long userId) {
-        em.createQuery(
+    public int deleteByUserId(Long userId) {
+        return em.createQuery(
                         "DELETE FROM UserBirdBookmark b WHERE b.user.id = :userId"
                 )
                 .setParameter("userId", userId)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/api/UserController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/api/UserController.java
@@ -212,4 +212,22 @@ public class UserController {
     ) {
         return userQueryService.checkNickname(nickname);
     }
+
+    @DeleteMapping("/me")
+    @PreAuthorize("hasRole('USER')")
+    @Operation(
+            summary = "회원 탈퇴",
+            description = """
+            회원을 탈퇴 처리합니다.
+            
+            실제로 서버에서 삭제되는 정보: 개인정보(이메일 주소), 도감 북마크 내역
+            서버에서 삭제되지 않는 정보: 과거 가입 내역, 소셜 계정 연동 내역, 회원이 올린 새록(컬렉션)
+            
+            """
+    )
+    public void deleteUserAccount(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        userCommandService.deleteUserAccount(userPrincipal.getId());
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/application/UserCommandService.java
@@ -101,23 +101,17 @@ public class UserCommandService {
                     .revoke(link);
         }
 
-        // 2) Full Delete
-        // 2-1) user_profile_image(+S3)
+        // 2) Hard Delete
         userProfileImageRepository.findByUserId(userId).ifPresent(img -> {
             String oldKey = img.getObjectKey();
             userProfileImageRepository.remove(img);
             runAfterCommitOrNow(() -> imageService.delete(oldKey));
         });
-        // 2-2) user_role
         userRoleRepository.deleteByUserId(userId);
-        // 2-3) user_refresh_token
         userRefreshTokenRepository.deleteByUserId(userId);
-        // 2-4) social_auth (Keep)
-        // - 내부 소셜 연동 정보는 보관합니다. (재가입 분석/감사를 위해)
-        // 2-5) user_bird_bookmark
         bookmarkRepository.deleteByUserId(userId);
 
-        // 3) Partial Delete (users)
+        // 3) Soft Delete
         user.anonymizeForWithdrawal();
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/application/helper/UserHardDeleteHelper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/application/helper/UserHardDeleteHelper.java
@@ -1,0 +1,48 @@
+// file: src/main/java/org/devkor/apu/saerok_server/domain/user/application/helper/UserHardDeleteHelper.java
+package org.devkor.apu.saerok_server.domain.user.application.helper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.devkor.apu.saerok_server.domain.auth.core.repository.UserRefreshTokenRepository;
+import org.devkor.apu.saerok_server.domain.dex.bookmark.core.repository.BookmarkRepository;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserProfileImageRepository;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRoleRepository;
+import org.devkor.apu.saerok_server.global.shared.infra.ImageService;
+import org.springframework.stereotype.Component;
+
+import static org.devkor.apu.saerok_server.global.shared.util.TransactionUtils.runAfterCommitOrNow;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserHardDeleteHelper {
+
+    private final UserProfileImageRepository userProfileImageRepository;
+    private final UserRoleRepository userRoleRepository;
+    private final UserRefreshTokenRepository userRefreshTokenRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final ImageService imageService;
+
+    /**
+     * 회원 탈퇴 시 영구 삭제가 필요한 리소스를 일괄 정리한다.
+     * 주의: 외부 스토리지(S3) 삭제는 커밋 후 실행(runAfterCommitOrNow)한다.
+     */
+    public void purgeAll(Long userId) {
+        purgeProfileImage(userId);
+        int roles = userRoleRepository.deleteByUserId(userId);
+        int tokens = userRefreshTokenRepository.deleteByUserId(userId);
+        int bookmarks = bookmarkRepository.deleteByUserId(userId);
+
+        log.info("[Withdrawal][HardDelete] userId={}, roles={}, refreshTokens={}, bookmarks={}",
+                userId, roles, tokens, bookmarks);
+    }
+
+    private void purgeProfileImage(Long userId) {
+        userProfileImageRepository.findByUserId(userId).ifPresent(img -> {
+            String oldKey = img.getObjectKey();
+            userProfileImageRepository.remove(img); // DB row 삭제
+            runAfterCommitOrNow(() -> imageService.delete(oldKey)); // 커밋 이후 S3 삭제
+            log.info("[Withdrawal][HardDelete] userId={}, profileImageKey={}", userId, oldKey);
+        });
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/SignupStatusType.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/SignupStatusType.java
@@ -2,5 +2,6 @@ package org.devkor.apu.saerok_server.domain.user.core.entity;
 
 public enum SignupStatusType {
     PROFILE_REQUIRED, // 소셜 인증만 된 상태 (닉네임 미입력)
-    COMPLETED // 소셜 인증 + 회원정보 모두 입력 완료
+    COMPLETED, // 소셜 인증 + 회원정보 모두 입력 완료
+    WITHDRAWN // 회원 탈퇴됨
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/User.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/User.java
@@ -46,6 +46,17 @@ public class User extends SoftDeletableAuditable {
     @Column(name = "default_profile_image_variant")
     private Short defaultProfileImageVariant;
 
+    public void anonymizeForWithdrawal() {
+        this.setNickname(null);
+        this.email = null;
+        this.phone = null;
+        this.gender = null;
+        this.birthDate = null;
+        this.setDefaultProfileImageVariant(null);
+        this.setSignupStatus(SignupStatusType.WITHDRAWN);
+        this.softDelete();
+    }
+
     public static User createUser(String email) {
         User user = new User();
         user.email = email;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/User.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/User.java
@@ -27,6 +27,7 @@ public class User extends SoftDeletableAuditable {
     @Column(name = "phone")
     private String phone;
 
+    @Setter
     @Column(name = "email")
     private String email;
 
@@ -55,6 +56,12 @@ public class User extends SoftDeletableAuditable {
         this.setDefaultProfileImageVariant(null);
         this.setSignupStatus(SignupStatusType.WITHDRAWN);
         this.softDelete();
+    }
+
+    public void restoreForRejoin() {
+        this.deletedAt = null; // Soft delete 해제
+        this.setSignupStatus(SignupStatusType.PROFILE_REQUIRED);
+        this.joinedAt = OffsetDateTime.now(); // 재가입 시점으로 갱신
     }
 
     public static User createUser(String email) {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/repository/UserRoleRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/repository/UserRoleRepository.java
@@ -23,4 +23,10 @@ public class UserRoleRepository {
                 .setParameter("user", user)
                 .getResultList();
     }
+
+    public void deleteByUserId(Long userId) {
+        em.createQuery("DELETE FROM UserRole ur WHERE ur.user.id = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/repository/UserRoleRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/repository/UserRoleRepository.java
@@ -24,8 +24,8 @@ public class UserRoleRepository {
                 .getResultList();
     }
 
-    public void deleteByUserId(Long userId) {
-        em.createQuery("DELETE FROM UserRole ur WHERE ur.user.id = :userId")
+    public int deleteByUserId(Long userId) {
+        return em.createQuery("DELETE FROM UserRole ur WHERE ur.user.id = :userId")
                 .setParameter("userId", userId)
                 .executeUpdate();
     }

--- a/src/main/java/org/devkor/apu/saerok_server/global/core/properties/KakaoProperties.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/core/properties/KakaoProperties.java
@@ -14,4 +14,5 @@ public class KakaoProperties {
     private String clientId;
     private String redirectUri;
     private String clientSecret;
+    private String adminKey;
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/shared/entity/SoftDeletableAuditable.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/shared/entity/SoftDeletableAuditable.java
@@ -2,10 +2,12 @@ package org.devkor.apu.saerok_server.global.shared.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
 import java.time.OffsetDateTime;
 
 @MappedSuperclass
+@Getter
 public abstract class SoftDeletableAuditable extends Auditable {
 
     @Column(name = "deleted_at")

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -59,6 +59,7 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}
   client-secret: ${KAKAO_CLIENT_SECRET}
+  admin-key: ${KAKAO_ADMIN_KEY}
 
 app:
   cookie:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -47,6 +47,7 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}
   client-secret: ${KAKAO_CLIENT_SECRET}
+  admin-key: ${KAKAO_ADMIN_KEY}
 
 app:
   cookie:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -62,6 +62,7 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}
   client-secret: ${KAKAO_CLIENT_SECRET}
+  admin-key: ${KAKAO_ADMIN_KEY}
 
 app:
   cookie:

--- a/src/test/java/org/devkor/apu/saerok_server/domain/user/application/UserCommandServiceTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/user/application/UserCommandServiceTest.java
@@ -1,8 +1,14 @@
 package org.devkor.apu.saerok_server.domain.user.application;
 
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialAuth;
+import org.devkor.apu.saerok_server.domain.auth.core.entity.SocialProviderType;
+import org.devkor.apu.saerok_server.domain.auth.core.repository.SocialAuthRepository;
+import org.devkor.apu.saerok_server.domain.auth.infra.SocialRevoker;
 import org.devkor.apu.saerok_server.domain.user.api.dto.response.ProfileImagePresignResponse;
 import org.devkor.apu.saerok_server.domain.user.api.dto.response.UpdateUserProfileResponse;
 import org.devkor.apu.saerok_server.domain.user.application.dto.UpdateUserProfileCommand;
+import org.devkor.apu.saerok_server.domain.user.application.helper.UserHardDeleteHelper;
+import org.devkor.apu.saerok_server.domain.user.core.entity.SignupStatusType;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
 import org.devkor.apu.saerok_server.domain.user.core.service.UserProfileImageUrlService;
@@ -10,17 +16,17 @@ import org.devkor.apu.saerok_server.domain.user.core.service.UserProfileUpdateSe
 import org.devkor.apu.saerok_server.domain.user.core.service.UserSignupStatusService;
 import org.devkor.apu.saerok_server.global.shared.exception.BadRequestException;
 import org.devkor.apu.saerok_server.global.shared.exception.NotFoundException;
-import org.devkor.apu.saerok_server.global.shared.infra.ImageDomainService;
 import org.devkor.apu.saerok_server.global.shared.infra.ImageService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -37,19 +43,29 @@ class UserCommandServiceTest {
     @Mock UserProfileUpdateService userProfileUpdateService;
     @Mock UserSignupStatusService userSignupStatusService;
     @Mock UserProfileImageUrlService userProfileImageUrlService;
-    @Mock ImageDomainService imageDomainService;
     @Mock ImageService imageService;
+
+    @Mock SocialAuthRepository socialAuthRepository;
+    @Mock UserHardDeleteHelper userHardDeleteHelper;
+
+    // Revokers (테스트별 필요 시에만 provider() 스텁)
+    @Mock SocialRevoker kakaoRevoker;
+    @Mock SocialRevoker appleRevoker;
 
     private User user;
 
     @BeforeEach
     void setUp() {
+        // 전역 불필요 스터빙 없음 (STRICT_STUBS 대응)
         sut = new UserCommandService(
                 userRepository,
                 userProfileUpdateService,
                 userSignupStatusService,
                 imageService,
-                userProfileImageUrlService
+                userProfileImageUrlService,
+                socialAuthRepository,
+                List.of(kakaoRevoker, appleRevoker),
+                userHardDeleteHelper
         );
 
         user = new User();
@@ -58,166 +74,223 @@ class UserCommandServiceTest {
         ReflectionTestUtils.setField(user, "email", "old@example.com");
     }
 
-    @Test
-    @DisplayName("updateUserProfile — 닉네임만 변경")
-    void updateUserProfile_nicknameOnly() {
-        // given
-        given(userRepository.findById(42L)).willReturn(Optional.of(user));
+    @Nested
+    class UpdateUserProfile {
 
-        // changeNickname 호출 시 실제로 user 닉네임을 바꾸도록 스텁
-        doAnswer(invocation -> {
-            User u = invocation.getArgument(0);
-            String newNick = invocation.getArgument(1);
-            u.setNickname(newNick);
-            return null;
-        }).when(userProfileUpdateService).changeNickname(same(user), eq("newNick"));
+        @Test
+        @DisplayName("닉네임만 변경하면 닉네임 변경 도메인 서비스 호출 및 응답 반영")
+        void nicknameOnly() {
+            given(userRepository.findById(42L)).willReturn(Optional.of(user));
+            doAnswer(invocation -> {
+                User u = invocation.getArgument(0);
+                String newNick = invocation.getArgument(1);
+                u.setNickname(newNick);
+                return null;
+            }).when(userProfileUpdateService).changeNickname(same(user), eq("newNick"));
+            given(userProfileImageUrlService.getProfileImageUrlFor(user)).willReturn(null);
 
-        UpdateUserProfileCommand cmd = new UpdateUserProfileCommand(
-                42L,
-                "newNick",
-                null,
-                null
-        );
+            UpdateUserProfileCommand cmd = new UpdateUserProfileCommand(42L, "newNick", null, null);
 
-        // when
-        UpdateUserProfileResponse res = sut.updateUserProfile(cmd);
+            UpdateUserProfileResponse res = sut.updateUserProfile(cmd);
 
-        // then
-        assertThat(res.nickname()).isEqualTo("newNick");
-        assertThat(res.email()).isEqualTo("old@example.com");
-        assertThat(res.profileImageUrl()).isNull();
+            assertThat(res.nickname()).isEqualTo("newNick");
+            assertThat(res.email()).isEqualTo("old@example.com");
+            assertThat(res.profileImageUrl()).isNull();
 
-        verify(userRepository).findById(42L);
-        verify(userProfileUpdateService).changeNickname(user, "newNick");
-        verify(userSignupStatusService).tryCompleteSignup(user);
+            verify(userRepository).findById(42L);
+            verify(userProfileUpdateService).changeNickname(user, "newNick");
+            verify(userSignupStatusService).tryCompleteSignup(user);
+            verify(userProfileImageUrlService).getProfileImageUrlFor(user);
+            verifyNoMoreInteractions(userProfileUpdateService);
+        }
 
-        // ImageDomainService는 호출되지 않음
-        verifyNoInteractions(imageDomainService);
+        @Test
+        @DisplayName("닉네임 정책 위반 시 BadRequestException 변환")
+        void badNickname_throwsBadRequest() {
+            given(userRepository.findById(42L)).willReturn(Optional.of(user));
+            doThrow(new IllegalArgumentException("정책 위반"))
+                    .when(userProfileUpdateService).changeNickname(user, "bad");
+
+            UpdateUserProfileCommand cmd = new UpdateUserProfileCommand(42L, "bad", null, null);
+
+            assertThatThrownBy(() -> sut.updateUserProfile(cmd))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessageContaining("정책 위반");
+        }
+
+        @Test
+        @DisplayName("사용자 없음 시 404")
+        void userNotFound() {
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            UpdateUserProfileCommand cmd = new UpdateUserProfileCommand(999L, "nick", null, null);
+
+            assertThatThrownBy(() -> sut.updateUserProfile(cmd))
+                    .isInstanceOf(NotFoundException.class);
+        }
     }
 
-    @Test
-    @DisplayName("updateUserProfile — 프로필 이미지 변경 포함")
-    void updateUserProfile_withImage() {
-        // given
-        given(userRepository.findById(42L)).willReturn(Optional.of(user));
-        String objKey = "user-profile-images/42/uuid";
+    @Nested
+    class PresignProfileImageUrl {
 
-        UpdateUserProfileCommand cmd = new UpdateUserProfileCommand(
-                42L,
-                null,                 // 닉네임 미변경
-                objKey,
-                "image/png"
-        );
+        @Test
+        @DisplayName("정상 발급 시 presigned URL과 objectKey 반환")
+        void ok() {
+            long userId = 77L;
+            User u = new User();
+            ReflectionTestUtils.setField(u, "id", userId);
+            given(userRepository.findById(userId)).willReturn(Optional.of(u));
 
-        // when
-        UpdateUserProfileResponse res = sut.updateUserProfile(cmd);
+            // 인자 매칭은 타입 기준으로, 실제 key는 verify에서 캡처
+            given(imageService.generateUploadUrl(anyString(), eq("image/jpeg"), anyLong()))
+                    .willReturn("https://presigned");
 
-        // then
-        assertThat(res.nickname()).isEqualTo("oldNick");
-        assertThat(res.email()).isEqualTo("old@example.com");
-        // 현재 구현은 URL을 응답에 포함하지 않는다고 가정
-        assertThat(res.profileImageUrl()).isNull();
+            ProfileImagePresignResponse resp = sut.generateProfileImagePresignUrl(userId, "image/jpeg");
 
-        verify(userRepository).findById(42L);
-        verify(userProfileUpdateService).changeProfileImage(user, objKey, "image/png");
-        verify(userSignupStatusService).tryCompleteSignup(user);
+            assertThat(resp.presignedUrl()).isEqualTo("https://presigned");
+            assertThat(resp.objectKey()).startsWith("user-profile-images/" + userId + "/");
 
-        // 닉네임 서비스는 호출되지 않음
-        verify(userProfileUpdateService, never()).changeNickname(any(), anyString());
+            ArgumentCaptor<String> keyCap = ArgumentCaptor.forClass(String.class);
+            verify(imageService).generateUploadUrl(keyCap.capture(), eq("image/jpeg"), anyLong());
+            assertThat(keyCap.getValue()).isEqualTo(resp.objectKey());
+
+            verify(userRepository).findById(userId);
+            verifyNoMoreInteractions(imageService);
+        }
+
+        @Test
+        @DisplayName("contentType 누락 시 400")
+        void missingContentType() {
+            long userId = 10L;
+            User u = new User();
+            ReflectionTestUtils.setField(u, "id", userId);
+            given(userRepository.findById(userId)).willReturn(Optional.of(u));
+
+            assertThatThrownBy(() -> sut.generateProfileImagePresignUrl(userId, ""))
+                    .isInstanceOf(BadRequestException.class);
+            verifyNoInteractions(imageService);
+        }
+
+        @Test
+        @DisplayName("사용자 없음 시 404")
+        void notFound() {
+            given(userRepository.findById(5L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.generateProfileImagePresignUrl(5L, "image/png"))
+                    .isInstanceOf(NotFoundException.class);
+            verifyNoInteractions(imageService);
+        }
     }
 
-    @Test
-    @DisplayName("updateUserProfile — 닉네임 정책 위반 시 400 변환")
-    void updateUserProfile_badNickname_throwsBadRequest() {
-        // given
-        given(userRepository.findById(42L)).willReturn(Optional.of(user));
-        doThrow(new IllegalArgumentException("정책 위반"))
-                .when(userProfileUpdateService).changeNickname(user, "bad");
+    @Nested
+    class DeleteProfileImage {
 
-        UpdateUserProfileCommand cmd = new UpdateUserProfileCommand(
-                42L, "bad", null, null);
+        @Test
+        @DisplayName("도메인 서비스로 위임")
+        void ok() {
+            long userId = 42L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-        // when / then
-        assertThatThrownBy(() -> sut.updateUserProfile(cmd))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining("정책 위반");
+            sut.deleteProfileImage(userId);
+
+            verify(userRepository).findById(userId);
+            verify(userProfileUpdateService).deleteProfileImage(user);
+            verifyNoMoreInteractions(userProfileUpdateService);
+        }
+
+        @Test
+        @DisplayName("사용자 없음 시 404")
+        void userNotFound() {
+            given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.deleteProfileImage(1L))
+                    .isInstanceOf(NotFoundException.class);
+            verifyNoInteractions(userProfileUpdateService);
+        }
     }
 
-    @Test
-    @DisplayName("updateUserProfile — 사용자 없음 시 404")
-    void updateUserProfile_userNotFound() {
-        given(userRepository.findById(999L)).willReturn(Optional.empty());
+    @Nested
+    class DeleteUserAccount {
 
-        UpdateUserProfileCommand cmd = new UpdateUserProfileCommand(
-                999L, "nick", null, null);
+        @Mock SocialAuth kakaoLink;
+        @Mock SocialAuth appleLink;
 
-        assertThatThrownBy(() -> sut.updateUserProfile(cmd))
-                .isInstanceOf(NotFoundException.class);
-    }
+        @Test
+        @DisplayName("정상 플로우: revoke → hard delete → soft delete")
+        void ok() {
+            long userId = 42L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-    @Test
-    @DisplayName("generateProfileImagePresignUrl — 정상 발급")
-    void generateProfileImagePresignUrl_ok() {
-        // given
-        long userId = 77L;
-        User u = new User();
-        ReflectionTestUtils.setField(u, "id", userId);
-        given(userRepository.findById(userId)).willReturn(Optional.of(u));
+            given(kakaoLink.getProvider()).willReturn(SocialProviderType.KAKAO);
+            given(appleLink.getProvider()).willReturn(SocialProviderType.APPLE);
+            given(socialAuthRepository.findByUserId(userId)).willReturn(List.of(kakaoLink, appleLink));
 
-        // presign 호출 시 생성되는 key를 캡처해서 응답과 일치하는지 검증
-        ArgumentCaptor<String> keyCap = ArgumentCaptor.forClass(String.class);
-        given(imageService.generateUploadUrl(keyCap.capture(), eq("image/jpeg"), eq(10L)))
-                .willReturn("https://presigned");
+            given(kakaoRevoker.provider()).willReturn(SocialProviderType.KAKAO);
+            given(appleRevoker.provider()).willReturn(SocialProviderType.APPLE);
 
-        // when
-        ProfileImagePresignResponse resp = sut.generateProfileImagePresignUrl(userId, "image/jpeg");
+            sut.deleteUserAccount(userId);
 
-        // then
-        assertThat(resp.presignedUrl()).isEqualTo("https://presigned");
-        assertThat(resp.objectKey()).startsWith("user-profile-images/" + userId + "/");
-        assertThat(keyCap.getValue()).isEqualTo(resp.objectKey());
+            verify(kakaoRevoker).revoke(kakaoLink);
+            verify(appleRevoker).revoke(appleLink);
+            verify(userHardDeleteHelper).purgeAll(userId);
 
-        verify(userRepository).findById(userId);
-        verify(imageService).generateUploadUrl(resp.objectKey(), "image/jpeg", 10L);
-    }
+            assertThat(user.getSignupStatus()).isEqualTo(SignupStatusType.WITHDRAWN);
+            assertThat(user.getDeletedAt()).isNotNull();
+        }
 
-    @Test
-    @DisplayName("generateProfileImagePresignUrl — contentType 누락 시 400")
-    void generateProfileImagePresignUrl_missingContentType() {
-        long userId = 10L;
-        User u = new User();
-        ReflectionTestUtils.setField(u, "id", userId);
-        given(userRepository.findById(userId)).willReturn(Optional.of(u));
+        @Test
+        @DisplayName("소셜 링크가 없어도 hard/soft delete는 수행됨 (revoker 호출 없음)")
+        void noLinksStillDeletes() {
+            long userId = 42L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(socialAuthRepository.findByUserId(userId)).willReturn(List.of()); // 링크 없음
 
-        assertThatThrownBy(() -> sut.generateProfileImagePresignUrl(userId, ""))
-                .isInstanceOf(BadRequestException.class);
-    }
+            sut.deleteUserAccount(userId);
 
-    @Test
-    @DisplayName("generateProfileImagePresignUrl — 사용자 없음 시 404")
-    void generateProfileImagePresignUrl_userNotFound() {
-        given(userRepository.findById(5L)).willReturn(Optional.empty());
-        assertThatThrownBy(() -> sut.generateProfileImagePresignUrl(5L, "image/png"))
-                .isInstanceOf(NotFoundException.class);
-    }
+            verifyNoInteractions(kakaoRevoker, appleRevoker);
+            verify(userHardDeleteHelper).purgeAll(userId);
+            assertThat(user.getSignupStatus()).isEqualTo(SignupStatusType.WITHDRAWN);
+        }
 
-    @Test
-    @DisplayName("deleteProfileImage — 도메인 서비스로 위임")
-    void deleteProfileImage_ok() {
-        long userId = 42L;
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        @Test
+        @DisplayName("해당 provider의 Revoker가 없으면 IllegalStateException")
+        void missingRevoker_throws() {
+            sut = new UserCommandService(
+                    userRepository,
+                    userProfileUpdateService,
+                    userSignupStatusService,
+                    imageService,
+                    userProfileImageUrlService,
+                    socialAuthRepository,
+                    List.of(kakaoRevoker), // APPLE revoker 누락
+                    userHardDeleteHelper
+            );
 
-        sut.deleteProfileImage(userId);
+            long userId = 42L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-        verify(userRepository).findById(userId);
-        verify(userProfileUpdateService).deleteProfileImage(user);
-    }
+            given(appleLink.getProvider()).willReturn(SocialProviderType.APPLE);
+            given(socialAuthRepository.findByUserId(userId)).willReturn(List.of(appleLink));
 
-    @Test
-    @DisplayName("deleteProfileImage — 사용자 없음 시 404")
-    void deleteProfileImage_userNotFound() {
-        given(userRepository.findById(1L)).willReturn(Optional.empty());
-        assertThatThrownBy(() -> sut.deleteProfileImage(1L))
-                .isInstanceOf(NotFoundException.class);
+            given(kakaoRevoker.provider()).willReturn(SocialProviderType.KAKAO);
+
+            assertThatThrownBy(() -> sut.deleteUserAccount(userId))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Revoker 미구현");
+
+            verifyNoInteractions(userHardDeleteHelper);
+            assertThat(user.getSignupStatus()).isNotEqualTo(SignupStatusType.WITHDRAWN);
+        }
+
+        @Test
+        @DisplayName("사용자 없음 시 404")
+        void userNotFound() {
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sut.deleteUserAccount(999L))
+                    .isInstanceOf(NotFoundException.class);
+
+            verifyNoInteractions(userHardDeleteHelper, kakaoRevoker, appleRevoker);
+        }
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

* **회원 탈퇴 (`DELETE /users/me`)**

  1. 연결된 소셜 계정(Apple, Kakao) 각각에 대해 `SocialRevoker`를 통해 연동 해제.
  2. `UserHardDeleteHelper`로 권한, 리프레시 토큰, 프로필 이미지, 북마크 등 영구 삭제. (새록/댓글/좋아요/신고 내역은 보존하여, 재가입 시 복구됨)
  3. `User.anonymizeForWithdrawal()` 호출로 개인정보 초기화, 상태 `WITHDRAWN` 설정, soft delete 처리.

* **재가입 시 재프로비저닝**

  * 기존 소셜 계정 연동 정보(`social_auth`)가 남아 있는 상태에서 동일 소셜 계정으로 로그인하면,

    * `SignupStatus`가 `WITHDRAWN`이면 `provisionRejoinedUser()` 실행.
    * Soft delete 해제, 상태를 `PROFILE_REQUIRED`로 변경, `joinedAt` 갱신.
    * 이메일·기본 프로필 이미지·USER 권한이 없으면 복구/부여.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.