### PR TITLE
feat: 알림 메시지 외부화 및 환경별 PushGateway 분리

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/render/ActionNotificationRenderer.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/render/ActionNotificationRenderer.java
@@ -1,13 +1,21 @@
 package org.devkor.apu.saerok_server.domain.notification.application.assembly.render;
 
+import lombok.RequiredArgsConstructor;
 import org.devkor.apu.saerok_server.domain.notification.application.model.payload.ActionNotificationPayload;
 import org.devkor.apu.saerok_server.domain.notification.application.model.payload.NotificationPayload;
 import org.devkor.apu.saerok_server.domain.notification.core.entity.NotificationType;
 import org.devkor.apu.saerok_server.domain.notification.core.service.NotificationTypeResolver;
+import org.devkor.apu.saerok_server.global.core.config.feature.NotificationMessagesConfig;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Component
+@RequiredArgsConstructor
 public class ActionNotificationRenderer implements NotificationRenderer {
+
+    private final NotificationMessagesConfig messages;
 
     @Override
     public RenderedMessage render(NotificationPayload p) {
@@ -16,23 +24,38 @@ public class ActionNotificationRenderer implements NotificationRenderer {
         }
 
         NotificationType type = NotificationTypeResolver.from(a.subject(), a.action());
+        NotificationMessagesConfig.Template t = messages.forType(type);
 
-        return switch (type) {
-            case LIKED_ON_COLLECTION -> new RenderedMessage(
-                    a.actorName() + "님이 나의 새록을 좋아해요.",   // inApp body
-                    a.actorName(),                         // push title
-                    "나의 새록을 좋아해요."     // push body
-            );
-            case COMMENTED_ON_COLLECTION -> new RenderedMessage(
-                    a.actorName() + "님이 나의 새록에 댓글을 남겼어요. \"" + a.extras().getOrDefault("comment", "") +"\"",
-                    a.actorName(),
-                    "나의 새록에 댓글을 남겼어요. \"" + a.extras().getOrDefault("comment", "") + "\""
-            );
-            case SUGGESTED_BIRD_ID_ON_COLLECTION -> new RenderedMessage(
-                    "두근두근! 새로운 의견이 공유되었어요. 확인해볼까요?",
-                    "동정 의견 공유",
-                    "두근두근! 새로운 의견이 공유되었어요. 확인해볼까요?"
-            );
-        };
+        Map<String, String> vars = new HashMap<>();
+        vars.put("actorName", nullToEmpty(a.actorName()));
+        a.extras().forEach((k, v) -> vars.put(k, v == null ? "" : String.valueOf(v)));
+
+        String inApp = renderTemplate(t.getInAppBody(), vars);
+        String title = renderTemplate(t.getPushTitle(), vars);
+        String body  = renderTemplate(t.getPushBody(), vars);
+
+        return new RenderedMessage(inApp, title, body);
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+
+    /**
+     * 템플릿 렌더링
+     * <ul>
+     * <li>{{var}} -> {var} (이스케이프)</li>
+     * <li>{var}   -> 값 치환</li>
+     * </ul>
+     */
+    private String renderTemplate(String template, Map<String, String> vars) {
+        if (template == null) return "";
+        String out = template.replace("{{", "\u0000").replace("}}", "\u0001"); // 임시 마커
+        for (Map.Entry<String, String> e : vars.entrySet()) {
+            String key = "{" + e.getKey() + "}";
+            out = out.replace(key, e.getValue() == null ? "" : e.getValue());
+        }
+        // 이스케이프 복원
+        return out.replace("\u0000", "{").replace("\u0001", "}");
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/infra/fcm/FcmPushGateway.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/infra/fcm/FcmPushGateway.java
@@ -10,12 +10,14 @@ import org.devkor.apu.saerok_server.domain.notification.core.entity.Notification
 import org.devkor.apu.saerok_server.domain.notification.core.repository.NotificationSettingRepository;
 import org.devkor.apu.saerok_server.domain.notification.core.repository.UserDeviceRepository;
 import org.devkor.apu.saerok_server.domain.notification.core.service.NotificationTypeResolver;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Slf4j
 @Component
+@Profile({"dev","prod"})
 @RequiredArgsConstructor
 public class FcmPushGateway implements PushGateway {
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/infra/local/LocalPushGateway.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/infra/local/LocalPushGateway.java
@@ -1,0 +1,56 @@
+package org.devkor.apu.saerok_server.domain.notification.infra.local;
+
+import lombok.extern.slf4j.Slf4j;
+import org.devkor.apu.saerok_server.domain.notification.application.dto.PushMessageCommand;
+import org.devkor.apu.saerok_server.domain.notification.application.gateway.PushGateway;
+import org.devkor.apu.saerok_server.domain.notification.core.entity.NotificationAction;
+import org.devkor.apu.saerok_server.domain.notification.core.entity.NotificationSubject;
+import org.devkor.apu.saerok_server.domain.notification.core.service.NotificationTypeResolver;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("local")
+public class LocalPushGateway implements PushGateway {
+
+    @Override
+    public void sendToUser(Long userId, NotificationSubject subject, NotificationAction action, PushMessageCommand cmd) {
+        String type = NotificationTypeResolver.from(subject, action).name();
+
+        log.info("""
+                
+                ┌───────────────── LOCAL PUSH (SIMULATED) ─────────────────┐
+                │ userId       : {}
+                │ subject      : {}
+                │ action       : {}
+                │ type         : {}
+                │ title        : {}
+                │ body         : {}
+                │ relatedId    : {}
+                │ deepLink     : {}
+                │ unreadCount  : {}
+                └──────────────────────────────────────────────────────────┘
+                """,
+                userId,
+                subject,
+                action,
+                type,
+                safe(cmd.title()),
+                safe(cmd.body()),
+                cmd.relatedId(),
+                safe(cmd.deepLink()),
+                cmd.unreadCount()
+        );
+    }
+
+    private String safe(String s) {
+        return s == null ? "" : s.replace("\n", "\\n");
+    }
+
+    private String clip(String s, int max) {
+        if (s == null) return "";
+        String flat = s.replace("\n", "\\n");
+        return flat.length() <= max ? flat : flat.substring(0, max) + "…";
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/infra/local/LocalPushGateway.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/infra/local/LocalPushGateway.java
@@ -47,10 +47,4 @@ public class LocalPushGateway implements PushGateway {
     private String safe(String s) {
         return s == null ? "" : s.replace("\n", "\\n");
     }
-
-    private String clip(String s, int max) {
-        if (s == null) return "";
-        String flat = s.replace("\n", "\\n");
-        return flat.length() <= max ? flat : flat.substring(0, max) + "…";
-    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/core/config/feature/NotificationMessagesConfig.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/core/config/feature/NotificationMessagesConfig.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 import org.devkor.apu.saerok_server.domain.notification.core.entity.NotificationType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.validation.annotation.Validated;
 
 import java.util.EnumMap;
 import java.util.EnumSet;

--- a/src/main/java/org/devkor/apu/saerok_server/global/core/config/feature/NotificationMessagesConfig.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/core/config/feature/NotificationMessagesConfig.java
@@ -1,0 +1,48 @@
+package org.devkor.apu.saerok_server.global.core.config.feature;
+
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.Setter;
+import org.devkor.apu.saerok_server.domain.notification.core.entity.NotificationType;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "notification-messages")
+public class NotificationMessagesConfig {
+
+    /** enum 키로 바인딩 (YAML 키는 NotificationType.name()) */
+    private Map<NotificationType, Template> types = new EnumMap<>(NotificationType.class);
+
+    public Template forType(NotificationType type) {
+        Template t = types.get(type);
+        if (t == null) {
+            throw new IllegalArgumentException("해당 NotificationType을 위한 메시지 템플릿이 없습니다: " + type.name());
+        }
+        return t;
+    }
+
+    /** 기동 시 누락된 템플릿 검증 */
+    @PostConstruct
+    void validateAllTypesPresent() {
+        var required = EnumSet.allOf(NotificationType.class);
+        required.removeAll(types.keySet());
+        if (!required.isEmpty()) {
+            throw new IllegalStateException("notification-messages.types에 누락된 NotificationType이 있습니다: " + required);
+        }
+    }
+
+    @Getter @Setter
+    public static class Template {
+        private String pushTitle;
+        private String pushBody;
+        private String inAppBody;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
       - "classpath:config/size-category-rules.yml"
       - "classpath:config/reserved-nicknames.yml"
       - "classpath:config/user-profile-images-default.yml"
+      - "classpath:config/notification-messages.yml"
 
 api_prefix: /api/v1
 

--- a/src/main/resources/config/notification-messages.yml
+++ b/src/main/resources/config/notification-messages.yml
@@ -1,0 +1,14 @@
+notification-messages:
+  types:
+    LIKED_ON_COLLECTION:
+      push-title: "{actorName}"
+      push-body: "나의 새록을 좋아해요."
+      in-app-body: "{actorName}님이 나의 새록을 좋아해요."
+    COMMENTED_ON_COLLECTION:
+      push-title: "{actorName}"
+      push-body: "나의 새록에 댓글을 남겼어요. \"{comment}\""
+      in-app-body: "{actorName}님이 나의 새록에 댓글을 남겼어요. \"{comment}\""
+    SUGGESTED_BIRD_ID_ON_COLLECTION:
+      push-title: "동정 의견 공유"
+      push-body: "두근두근! 새로운 의견이 공유되었어요. 확인해볼까요?"
+      in-app-body: "두근두근! 새로운 의견이 공유되었어요. 확인해볼까요?"


### PR DESCRIPTION
## 📝 요약(Summary)

이번 PR에서는 알림 메시지를 코드에서 떼어내서 설정 파일(YAML)로 관리하게 바꿨고,
환경마다 PushGateway가 다르게 동작하도록 분리했어요.

---

### 1. 알림 메시지 외부화

* `config/notification-messages.yml` 파일 추가
* `NotificationMessagesConfig` 클래스로 메시지를 불러오고, `ActionNotificationRenderer`에서 템플릿 기반으로 메시지 만드는 구조로 변경했어요.
* 이제 `{actorName}`, `{comment}` 같은 변수를 치환해서 메시지를 만들 수 있어요.

```yaml
# config/notification-messages.yml
notification-messages:
  types:
    LIKED_ON_COLLECTION:
      push-title: "{actorName}"
      push-body: "나의 새록을 좋아해요."
      in-app-body: "{actorName}님이 나의 새록을 좋아해요."
    COMMENTED_ON_COLLECTION:
      push-title: "{actorName}"
      push-body: "나의 새록에 댓글을 남겼어요. \"{comment}\""
      in-app-body: "{actorName}님이 나의 새록에 댓글을 남겼어요. \"{comment}\""
    SUGGESTED_BIRD_ID_ON_COLLECTION:
      push-title: "동정 의견 공유"
      push-body: "두근두근! 새로운 의견이 공유되었어요. 확인해볼까요?"
      in-app-body: "두근두근! 새로운 의견이 공유되었어요. 확인해볼까요?"
```

---

### 2. 환경별 PushGateway 분리

* **dev/prod** → `FcmPushGateway` (실제로 푸시 전송)
* **local** → `LocalPushGateway` (푸시 대신 콘솔에 모의 전송 로그 출력)

<img width="612" height="307" alt="image" src="https://github.com/user-attachments/assets/346638a5-5e5c-4959-8ac7-cb748f24968c" />


---

### 기대 효과

* 알림 문구 바꿀 때 코드 안 건드리고 **YAML만 수정**하면 돼요.
* 환경별로 푸시 동작을 분리해서 **로컬에서 마음 놓고 테스트**할 수 있어요.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.