### PR TITLE
feat: 인앱알림 메시지 렌더링 로직 제거

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/render/ActionNotificationRenderer.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/render/ActionNotificationRenderer.java
@@ -30,11 +30,10 @@ public class ActionNotificationRenderer implements NotificationRenderer {
         vars.put("actorName", nullToEmpty(a.actorName()));
         a.extras().forEach((k, v) -> vars.put(k, v == null ? "" : String.valueOf(v)));
 
-        String inApp = renderTemplate(t.getInAppBody(), vars);
         String title = renderTemplate(t.getPushTitle(), vars);
         String body  = renderTemplate(t.getPushBody(), vars);
 
-        return new RenderedMessage(inApp, title, body);
+        return new RenderedMessage(title, body);
     }
 
     private static String nullToEmpty(String s) {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/render/NotificationRenderer.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/render/NotificationRenderer.java
@@ -6,8 +6,7 @@ public interface NotificationRenderer {
     RenderedMessage render(NotificationPayload payload);
 
     /**
-     * <h2>inAppBody</h2><p>인앱 알림 목록에 저장될 본문 (body-only)</p>
      * <h2>pushTitle / pushBody</h2><p>푸시 알림용 타이틀/본문</p>
      */
-    record RenderedMessage(String inAppBody, String pushTitle, String pushBody) { }
+    record RenderedMessage(String pushTitle, String pushBody) { }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/store/InAppNotificationWriter.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/store/InAppNotificationWriter.java
@@ -1,7 +1,6 @@
 package org.devkor.apu.saerok_server.domain.notification.application.assembly.store;
 
 import lombok.RequiredArgsConstructor;
-import org.devkor.apu.saerok_server.domain.notification.application.assembly.render.NotificationRenderer.RenderedMessage;
 import org.devkor.apu.saerok_server.domain.notification.application.model.payload.ActionNotificationPayload;
 import org.devkor.apu.saerok_server.domain.notification.application.model.payload.NotificationPayload;
 import org.devkor.apu.saerok_server.domain.notification.core.entity.Notification;
@@ -19,7 +18,7 @@ public class InAppNotificationWriter {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
-    public void save(NotificationPayload payload, RenderedMessage r, String deepLink) {
+    public void save(NotificationPayload payload, String deepLink) {
         if (!(payload instanceof ActionNotificationPayload a)) {
             throw new IllegalArgumentException("Unsupported payload: " + payload.getClass());
         }
@@ -34,7 +33,6 @@ public class InAppNotificationWriter {
 
         Notification entity = Notification.builder()
                 .user(recipient)
-                .body(r.inAppBody())
                 .type(type)
                 .relatedId(a.relatedId())
                 .deepLink(deepLink)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotificationPublisher.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotificationPublisher.java
@@ -37,7 +37,7 @@ public class NotificationPublisher {
 
         RenderedMessage renderedMessage = renderer.render(payload);
         String deepLink = deepLinkResolver.resolve(target);
-        inAppWriter.save(payload, renderedMessage, deepLink);
+        inAppWriter.save(payload, deepLink);
 
         int unread = notificationRepository.countUnreadByUserId(payload.recipientId()).intValue();
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/core/entity/Notification.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/core/entity/Notification.java
@@ -21,9 +21,6 @@ public class Notification extends CreatedAtOnly {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "body", nullable = false, columnDefinition = "TEXT")
-    private String body;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false, length = 64)
     private NotificationType type;
@@ -43,18 +40,15 @@ public class Notification extends CreatedAtOnly {
 
     @Builder
     public Notification(User user,
-                        String body,
                         NotificationType type,
                         Long relatedId,
                         String deepLink,
                         User actor,
                         Boolean isRead) {
         if (user == null) { throw new IllegalArgumentException("user는 null일 수 없습니다."); }
-        if (body == null || body.trim().isEmpty()) { throw new IllegalArgumentException("body는 비어있을 수 없습니다."); }
         if (type == null) { throw new IllegalArgumentException("type은 null일 수 없습니다."); }
 
         this.user = user;
-        this.body = body;
         this.type = type;
         this.relatedId = relatedId;
         this.deepLink = deepLink;

--- a/src/main/resources/config/notification-messages.yml
+++ b/src/main/resources/config/notification-messages.yml
@@ -3,12 +3,9 @@ notification-messages:
     LIKED_ON_COLLECTION:
       push-title: "{actorName}"
       push-body: "나의 새록을 좋아해요."
-      in-app-body: "{actorName}님이 나의 새록을 좋아해요."
     COMMENTED_ON_COLLECTION:
       push-title: "{actorName}"
       push-body: "나의 새록에 댓글을 남겼어요. \"{comment}\""
-      in-app-body: "{actorName}님이 나의 새록에 댓글을 남겼어요. \"{comment}\""
     SUGGESTED_BIRD_ID_ON_COLLECTION:
       push-title: "동정 의견 공유"
       push-body: "두근두근! 새로운 의견이 공유되었어요. 확인해볼까요?"
-      in-app-body: "두근두근! 새로운 의견이 공유되었어요. 확인해볼까요?"

--- a/src/main/resources/db/migration/V49__delete_notification_body.sql
+++ b/src/main/resources/db/migration/V49__delete_notification_body.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notification DROP COLUMN body;


### PR DESCRIPTION
## 📝 요약(Summary)

인앱알림 메시지 렌더링 로직을 제거했습니다. (프론트 책임으로 이관)
Closes #136 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.