### PR TITLE
feat: 알림 응답 확장: 컬렉션 이미지·액터 프로필 이미지 추가 및 payload 구조 전환

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/api/dto/response/GetNotificationsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/api/dto/response/GetNotificationsResponse.java
@@ -16,9 +16,6 @@ public record GetNotificationsResponse(
             @Schema(description = "알림 ID")
             Long id,
 
-            @Schema(description = "내용", example = "새록님이 좋아요를 눌렀어요")
-            String body,
-
             @Schema(description = "알림 식별자", example = "LIKED_ON_COLLECTION")
             NotificationType type,
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/api/dto/response/GetNotificationsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/api/dto/response/GetNotificationsResponse.java
@@ -29,6 +29,10 @@ public record GetNotificationsResponse(
             @Schema(description = "알림을 일으킨 사람 닉네임", example = "새록")
             String actorNickname,
 
+            @Schema(description = "알림을 일으킨 사람 프로필 이미지 URL",
+                    example = "https://cdn.saerok.dev/user-profile-images/3.jpg")
+            String actorProfileImageUrl,
+
             @Schema(description = "추가 메타데이터")
             Map<String, Object> payload,
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/api/dto/response/GetNotificationsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/api/dto/response/GetNotificationsResponse.java
@@ -5,6 +5,7 @@ import org.devkor.apu.saerok_server.domain.notification.core.entity.Notification
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Schema(description = "알림 목록 조회 응답")
 public record GetNotificationsResponse(
@@ -30,6 +31,9 @@ public record GetNotificationsResponse(
 
             @Schema(description = "알림을 일으킨 사람 닉네임", example = "새록")
             String actorNickname,
+
+            @Schema(description = "추가 메타데이터")
+            Map<String, Object> payload,
 
             @Schema(description = "읽음 여부")
             Boolean isRead,

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/api/dto/response/GetNotificationsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/api/dto/response/GetNotificationsResponse.java
@@ -20,9 +20,6 @@ public record GetNotificationsResponse(
             @Schema(description = "알림 식별자", example = "LIKED_ON_COLLECTION")
             NotificationType type,
 
-            @Schema(description = "관련 ID (예: 컬렉션 ID)", example = "52")
-            Long relatedId,
-
             @Schema(description = "딥링크 URL")
             String deepLink,
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/NotificationQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/NotificationQueryService.java
@@ -7,6 +7,7 @@ import org.devkor.apu.saerok_server.domain.notification.core.entity.Notification
 import org.devkor.apu.saerok_server.domain.notification.core.repository.NotificationRepository;
 import org.devkor.apu.saerok_server.domain.notification.mapper.NotificationWebMapper;
 import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
+import org.devkor.apu.saerok_server.domain.user.core.service.UserProfileImageUrlService;
 import org.devkor.apu.saerok_server.global.shared.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,17 +22,18 @@ public class NotificationQueryService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
     private final NotificationWebMapper notificationWebMapper;
+    private final UserProfileImageUrlService userProfileImageUrlService;
 
     public GetNotificationsResponse getNotifications(Long userId) {
         userRepository.findById(userId).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
-        
+
         List<Notification> notifications = notificationRepository.findByUserId(userId);
-        return notificationWebMapper.toGetNotificationsResponse(notifications);
+        return notificationWebMapper.toGetNotificationsResponse(notifications, userProfileImageUrlService);
     }
 
     public GetUnreadCountResponse getUnreadCount(Long userId) {
         userRepository.findById(userId).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
-        
+
         Long unreadCount = notificationRepository.countUnreadByUserId(userId);
         return notificationWebMapper.toGetUnreadCountResponse(unreadCount);
     }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/adapter/CollectionTargetMetadataAdapter.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/adapter/CollectionTargetMetadataAdapter.java
@@ -1,0 +1,42 @@
+package org.devkor.apu.saerok_server.domain.notification.application.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.collection.application.helper.CollectionImageUrlService;
+import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
+import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.Target;
+import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.TargetType;
+import org.devkor.apu.saerok_server.domain.notification.application.port.TargetMetadataPort;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * TargetType.COLLECTION 전용 메타데이터 어댑터.<br>
+ * - extras.collectionId<br>
+ * - extras.collectionImageUrl (없으면 null 넣어 키 유지)
+ */
+@Component
+@RequiredArgsConstructor
+public class CollectionTargetMetadataAdapter implements TargetMetadataPort {
+
+    private final CollectionRepository collectionRepository;
+    private final CollectionImageUrlService collectionImageUrlService;
+
+    @Override
+    public Map<String, Object> enrich(Target target, Map<String, Object> baseExtras) {
+        if (target.type() != TargetType.COLLECTION) {
+            return baseExtras != null ? baseExtras : Map.of();
+        }
+
+        Map<String, Object> extras = baseExtras != null ? new HashMap<>(baseExtras) : new HashMap<>();
+        extras.put("collectionId", target.id());
+
+        String imageUrl = collectionRepository.findById(target.id())
+                .flatMap(collectionImageUrlService::getPrimaryImageUrlFor)
+                .orElse(null);
+        extras.put("collectionImageUrl", imageUrl);
+
+        return extras;
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/store/InAppNotificationWriter.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/store/InAppNotificationWriter.java
@@ -34,15 +34,12 @@ public class InAppNotificationWriter {
 
         NotificationType type = NotificationTypeResolver.from(a.subject(), a.action());
 
-        // extras + relatedId를 합쳐 payload(jsonb)에 저장
         Map<String, Object> payloadMap = new HashMap<>();
         if (a.extras() != null) payloadMap.putAll(a.extras());
-        payloadMap.put("relatedId", a.relatedId());
 
         Notification entity = Notification.builder()
                 .user(recipient)
                 .type(type)
-                // .relatedId(a.relatedId())  // 더 이상 직접 쓰지 않음 (payload.relatedId로 이동)
                 .deepLink(deepLink)
                 .actor(actor)
                 .isRead(false)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/store/InAppNotificationWriter.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/store/InAppNotificationWriter.java
@@ -11,6 +11,9 @@ import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Component
 @RequiredArgsConstructor
 public class InAppNotificationWriter {
@@ -31,13 +34,19 @@ public class InAppNotificationWriter {
 
         NotificationType type = NotificationTypeResolver.from(a.subject(), a.action());
 
+        // extras + relatedId를 합쳐 payload(jsonb)에 저장
+        Map<String, Object> payloadMap = new HashMap<>();
+        if (a.extras() != null) payloadMap.putAll(a.extras());
+        payloadMap.put("relatedId", a.relatedId());
+
         Notification entity = Notification.builder()
                 .user(recipient)
                 .type(type)
-                .relatedId(a.relatedId())
+                // .relatedId(a.relatedId())  // 더 이상 직접 쓰지 않음 (payload.relatedId로 이동)
                 .deepLink(deepLink)
                 .actor(actor)
                 .isRead(false)
+                .payload(payloadMap)
                 .build();
 
         notificationRepository.save(entity);

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotificationPublisher.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotificationPublisher.java
@@ -30,7 +30,6 @@ public class NotificationPublisher {
     @Transactional
     public void push(NotificationPayload payload, Target target) {
 
-        // 알림을 받을 유저가 없는 경우(ex: 탈퇴된 유저) early return
         if (userRepository.findById(payload.recipientId()).isEmpty()) {
             return;
         }
@@ -48,10 +47,9 @@ public class NotificationPublisher {
         String typeString = NotificationTypeResolver.from(a.subject(), a.action()).name();
 
         PushMessageCommand cmd = PushMessageCommand.createPushMessageCommand(
-                renderedMessage.pushTitle(), renderedMessage.pushBody(), typeString, a.relatedId(), deepLink, unread
+                renderedMessage.pushTitle(), renderedMessage.pushBody(), typeString, target.id(), deepLink, unread
         );
 
-        // subject/action 축은 내부 용도이므로 게이트웨이에 그대로 전달 (게이트웨이 내부에서 type 기준 검사)
         pushGateway.sendToUser(a.recipientId(), a.subject(), a.action(), cmd);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotifyActionDsl.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotifyActionDsl.java
@@ -1,6 +1,8 @@
 package org.devkor.apu.saerok_server.domain.notification.application.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.domain.collection.application.helper.CollectionImageUrlService;
+import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
 import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.ActionKind;
 import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.Actor;
 import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.Target;
@@ -17,56 +19,122 @@ import java.util.Map;
 public class NotifyActionDsl {
 
     private final NotificationPublisher publisher;
+    private final CollectionRepository collectionRepository;
+    private final CollectionImageUrlService collectionImageUrlService;
 
-    public StepOn by(Actor actor) { return new StepOn(publisher, actor); }
+    public StepOn by(Actor actor) {
+        return new StepOn(publisher, collectionRepository, collectionImageUrlService, actor);
+    }
 
     public static class StepOn {
         private final NotificationPublisher publisher;
+        private final CollectionRepository collectionRepository;
+        private final CollectionImageUrlService collectionImageUrlService;
         private final Actor actor;
-        StepOn(NotificationPublisher p, Actor a){ this.publisher = p; this.actor = a; }
-        public StepDid on(Target target){ return new StepDid(publisher, actor, target); }
+
+        StepOn(NotificationPublisher p,
+               CollectionRepository cr,
+               CollectionImageUrlService ciu,
+               Actor a) {
+            this.publisher = p;
+            this.collectionRepository = cr;
+            this.collectionImageUrlService = ciu;
+            this.actor = a;
+        }
+
+        public StepDid on(Target target) {
+            return new StepDid(publisher, collectionRepository, collectionImageUrlService, actor, target);
+        }
     }
 
     public static class StepDid {
         private final NotificationPublisher publisher;
+        private final CollectionRepository collectionRepository;
+        private final CollectionImageUrlService collectionImageUrlService;
         private final Actor actor;
         private final Target target;
-        StepDid(NotificationPublisher p, Actor a, Target t){ this.publisher = p; this.actor = a; this.target = t; }
-        public StepTo did(ActionKind kind){ return new StepTo(publisher, actor, target, kind, new HashMap<>()); }
+
+        StepDid(NotificationPublisher p,
+                CollectionRepository cr,
+                CollectionImageUrlService ciu,
+                Actor a,
+                Target t) {
+            this.publisher = p;
+            this.collectionRepository = cr;
+            this.collectionImageUrlService = ciu;
+            this.actor = a;
+            this.target = t;
+        }
+
+        public StepTo did(ActionKind kind) {
+            return new StepTo(publisher, collectionRepository, collectionImageUrlService, actor, target, kind, new HashMap<>());
+        }
     }
 
     public static class StepTo {
         private final NotificationPublisher publisher;
+        private final CollectionRepository collectionRepository;
+        private final CollectionImageUrlService collectionImageUrlService;
         private final Actor actor;
         private final Target target;
         private final ActionKind action;
-        private final Map<String,Object> extras;
+        private final Map<String, Object> extras;
 
-        StepTo(NotificationPublisher p, Actor a, Target t, ActionKind k, Map<String,Object> ex) {
-            this.publisher = p; this.actor = a; this.target = t; this.action = k; this.extras = ex;
+        StepTo(NotificationPublisher p,
+               CollectionRepository cr,
+               CollectionImageUrlService ciu,
+               Actor a,
+               Target t,
+               ActionKind k,
+               Map<String, Object> ex) {
+            this.publisher = p;
+            this.collectionRepository = cr;
+            this.collectionImageUrlService = ciu;
+            this.actor = a;
+            this.target = t;
+            this.action = k;
+            this.extras = ex;
         }
 
         // 선택 파라미터들
-        public StepTo comment(String content){ extras.put("comment", content); return this; }
-        public StepTo suggestedName(String name){ extras.put("suggestedName", name); return this; }
+        public StepTo comment(String content) {
+            extras.put("comment", content);
+            return this;
+        }
 
-        public void to(Long recipientId){
-            NotificationSubject notificationSubject = switch (target.type()) {
+        public StepTo suggestedName(String name) {
+            extras.put("suggestedName", name);
+            return this;
+        }
+
+        public void to(Long recipientId) {
+            var notificationSubject = switch (target.type()) {
                 case COLLECTION -> NotificationSubject.COLLECTION;
             };
 
-            NotificationAction notificationAction = switch (action) {
+            var notificationAction = switch (action) {
                 case LIKE -> NotificationAction.LIKE;
                 case COMMENT -> NotificationAction.COMMENT;
                 case SUGGEST_BIRD_ID -> NotificationAction.SUGGEST_BIRD_ID;
             };
+
+            // TargetType별 extras 구성
+            switch (target.type()) {
+                case COLLECTION -> {
+                    extras.put("collectionId", target.id());
+
+                    String imageUrl = collectionRepository.findById(target.id())
+                            .flatMap(collectionImageUrlService::getPrimaryImageUrlFor)
+                            .orElse(null);
+                    extras.put("collectionImageUrl", imageUrl);
+                }
+            }
 
             publisher.push(
                     new ActionNotificationPayload(
                             recipientId,
                             actor.id(),
                             actor.name(),
-                            target.id(),
                             notificationSubject,
                             notificationAction,
                             extras

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotifyActionDsl.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotifyActionDsl.java
@@ -1,12 +1,11 @@
 package org.devkor.apu.saerok_server.domain.notification.application.facade;
 
 import lombok.RequiredArgsConstructor;
-import org.devkor.apu.saerok_server.domain.collection.application.helper.CollectionImageUrlService;
-import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
 import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.ActionKind;
 import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.Actor;
 import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.Target;
 import org.devkor.apu.saerok_server.domain.notification.application.model.payload.ActionNotificationPayload;
+import org.devkor.apu.saerok_server.domain.notification.application.port.TargetMetadataPort;
 import org.devkor.apu.saerok_server.domain.notification.core.entity.NotificationAction;
 import org.devkor.apu.saerok_server.domain.notification.core.entity.NotificationSubject;
 import org.springframework.stereotype.Component;
@@ -19,91 +18,83 @@ import java.util.Map;
 public class NotifyActionDsl {
 
     private final NotificationPublisher publisher;
-    private final CollectionRepository collectionRepository;
-    private final CollectionImageUrlService collectionImageUrlService;
+    private final TargetMetadataPort targetMetadataPort;
 
     public StepOn by(Actor actor) {
-        return new StepOn(publisher, collectionRepository, collectionImageUrlService, actor);
+        return new StepOn(publisher, targetMetadataPort, actor);
     }
 
     public static class StepOn {
         private final NotificationPublisher publisher;
-        private final CollectionRepository collectionRepository;
-        private final CollectionImageUrlService collectionImageUrlService;
+        private final TargetMetadataPort targetMetadataPort;
         private final Actor actor;
 
-        StepOn(NotificationPublisher p,
-               CollectionRepository cr,
-               CollectionImageUrlService ciu,
-               Actor a) {
+        StepOn(NotificationPublisher p, TargetMetadataPort port, Actor a) {
             this.publisher = p;
-            this.collectionRepository = cr;
-            this.collectionImageUrlService = ciu;
+            this.targetMetadataPort = port;
             this.actor = a;
         }
 
+        /**
+         * 대상 지정. 이 시점에 Target만으로 계산 가능한 메타(extras)를 확정한다.
+         */
         public StepDid on(Target target) {
-            return new StepDid(publisher, collectionRepository, collectionImageUrlService, actor, target);
+            Map<String, Object> base = targetMetadataPort.enrich(target, Map.of());
+            return new StepDid(publisher, actor, target, new HashMap<>(base));
         }
     }
 
     public static class StepDid {
         private final NotificationPublisher publisher;
-        private final CollectionRepository collectionRepository;
-        private final CollectionImageUrlService collectionImageUrlService;
         private final Actor actor;
         private final Target target;
+        private final Map<String, Object> baseExtras; // on()에서 확정된 기본 메타
 
-        StepDid(NotificationPublisher p,
-                CollectionRepository cr,
-                CollectionImageUrlService ciu,
-                Actor a,
-                Target t) {
+        StepDid(NotificationPublisher p, Actor a, Target t, Map<String, Object> base) {
             this.publisher = p;
-            this.collectionRepository = cr;
-            this.collectionImageUrlService = ciu;
             this.actor = a;
             this.target = t;
+            this.baseExtras = (base == null) ? new HashMap<>() : new HashMap<>(base);
         }
 
+        /**
+         * 수행한 액션 지정. on()에서 만든 메타를 이어받아 누적한다.
+         */
         public StepTo did(ActionKind kind) {
-            return new StepTo(publisher, collectionRepository, collectionImageUrlService, actor, target, kind, new HashMap<>());
+            return new StepTo(publisher, actor, target, kind, new HashMap<>(baseExtras));
         }
     }
 
     public static class StepTo {
         private final NotificationPublisher publisher;
-        private final CollectionRepository collectionRepository;
-        private final CollectionImageUrlService collectionImageUrlService;
         private final Actor actor;
         private final Target target;
         private final ActionKind action;
-        private final Map<String, Object> extras;
+        private final Map<String, Object> extras; // 누적되는 선택 파라미터
 
         StepTo(NotificationPublisher p,
-               CollectionRepository cr,
-               CollectionImageUrlService ciu,
                Actor a,
                Target t,
                ActionKind k,
                Map<String, Object> ex) {
             this.publisher = p;
-            this.collectionRepository = cr;
-            this.collectionImageUrlService = ciu;
             this.actor = a;
             this.target = t;
             this.action = k;
-            this.extras = ex;
+            this.extras = (ex == null) ? new HashMap<>() : new HashMap<>(ex);
         }
 
-        // 선택 파라미터들
         public StepTo comment(String content) {
-            extras.put("comment", content);
+            if (content != null && !content.isEmpty()) {
+                extras.put("comment", content);
+            }
             return this;
         }
 
         public StepTo suggestedName(String name) {
-            extras.put("suggestedName", name);
+            if (name != null && !name.isEmpty()) {
+                extras.put("suggestedName", name);
+            }
             return this;
         }
 
@@ -117,18 +108,6 @@ public class NotifyActionDsl {
                 case COMMENT -> NotificationAction.COMMENT;
                 case SUGGEST_BIRD_ID -> NotificationAction.SUGGEST_BIRD_ID;
             };
-
-            // TargetType별 extras 구성
-            switch (target.type()) {
-                case COLLECTION -> {
-                    extras.put("collectionId", target.id());
-
-                    String imageUrl = collectionRepository.findById(target.id())
-                            .flatMap(collectionImageUrlService::getPrimaryImageUrlFor)
-                            .orElse(null);
-                    extras.put("collectionImageUrl", imageUrl);
-                }
-            }
 
             publisher.push(
                     new ActionNotificationPayload(

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/model/payload/ActionNotificationPayload.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/model/payload/ActionNotificationPayload.java
@@ -9,7 +9,6 @@ public record ActionNotificationPayload(
         Long recipientId,
         Long actorId,
         String actorName,
-        Long relatedId,
         NotificationSubject subject,
         NotificationAction action,
         Map<String, Object> extras

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/model/payload/NotificationPayload.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/model/payload/NotificationPayload.java
@@ -10,7 +10,6 @@ public sealed interface NotificationPayload
 
     NotificationSubject subject();
     NotificationAction action();
-    Long recipientId();           // D: 알림 받을 사람
-    Long relatedId();             // 관련 리소스 id (ex. collectionId)
-    Map<String, Object> extras(); // 템플릿 변수 (코멘트 내용 등)
+    Long recipientId();           // 알림 받을 사람
+    Map<String, Object> extras(); // 메타데이터 (ex. comment, collectionId, collectionImageUrl ...)
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/port/TargetMetadataPort.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/port/TargetMetadataPort.java
@@ -1,0 +1,19 @@
+package org.devkor.apu.saerok_server.domain.notification.application.port;
+
+import org.devkor.apu.saerok_server.domain.notification.application.model.dsl.Target;
+
+import java.util.Map;
+
+/**
+ * Target에 맞는 메타데이터(extras)를 조립/보강해 주는 포트.
+ * - DSL은 이 인터페이스만 의존하고, 실제 구현은 어댑터가 담당한다.
+ */
+public interface TargetMetadataPort {
+
+    /**
+     * @param target     알림의 대상으로 지정된 Target (예: COLLECTION)
+     * @param baseExtras DSL에서 누적한 기본 extras (comment, suggestedName 등)
+     * @return target에 맞춰 보강된 extras 맵
+     */
+    Map<String, Object> enrich(Target target, Map<String, Object> baseExtras);
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/core/entity/Notification.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/core/entity/Notification.java
@@ -6,6 +6,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.global.shared.entity.CreatedAtOnly;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Entity
 @Table(name = "notification")
@@ -28,6 +33,10 @@ public class Notification extends CreatedAtOnly {
     @Column(name = "related_id")
     private Long relatedId;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
+    private Map<String, Object> payload;
+
     @Column(name = "deep_link", length = 500)
     private String deepLink;
 
@@ -44,16 +53,22 @@ public class Notification extends CreatedAtOnly {
                         Long relatedId,
                         String deepLink,
                         User actor,
-                        Boolean isRead) {
+                        Boolean isRead,
+                        Map<String, Object> payload) {
         if (user == null) { throw new IllegalArgumentException("user는 null일 수 없습니다."); }
         if (type == null) { throw new IllegalArgumentException("type은 null일 수 없습니다."); }
 
         this.user = user;
         this.type = type;
-        this.relatedId = relatedId;
+        this.relatedId = relatedId; // 남겨두되 신규 쓰기는 payload.relatedId 사용
         this.deepLink = deepLink;
         this.actor = actor;
         this.isRead = isRead != null ? isRead : false;
+        if (payload != null) {
+            this.payload = new HashMap<>(payload);
+        } else {
+            this.payload = new HashMap<>();
+        }
     }
 
     public void markAsRead() { this.isRead = true; }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/core/entity/Notification.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/core/entity/Notification.java
@@ -30,9 +30,6 @@ public class Notification extends CreatedAtOnly {
     @Column(name = "type", nullable = false, length = 64)
     private NotificationType type;
 
-    @Column(name = "related_id")
-    private Long relatedId;
-
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "payload", columnDefinition = "jsonb", nullable = false)
     private Map<String, Object> payload;
@@ -50,7 +47,6 @@ public class Notification extends CreatedAtOnly {
     @Builder
     public Notification(User user,
                         NotificationType type,
-                        Long relatedId,
                         String deepLink,
                         User actor,
                         Boolean isRead,
@@ -60,7 +56,6 @@ public class Notification extends CreatedAtOnly {
 
         this.user = user;
         this.type = type;
-        this.relatedId = relatedId; // 남겨두되 신규 쓰기는 payload.relatedId 사용
         this.deepLink = deepLink;
         this.actor = actor;
         this.isRead = isRead != null ? isRead : false;

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/mapper/NotificationWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/mapper/NotificationWebMapper.java
@@ -8,6 +8,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import java.util.List;
+import java.util.Map;
 
 @Mapper(componentModel = "spring",
         imports = OffsetDateTimeLocalizer.class)
@@ -25,5 +26,17 @@ public interface NotificationWebMapper {
     @Mapping(target = "actorId", source = "actor.id")
     @Mapping(target = "actorNickname", source = "actor.nickname")
     @Mapping(target = "createdAt", expression = "java(OffsetDateTimeLocalizer.toSeoulLocalDateTime(notification.getCreatedAt()))")
+    @Mapping(target = "payload", expression = "java(notification.getPayload())")
+    @Mapping(target = "relatedId", expression = "java(resolveRelatedId(notification))")
     GetNotificationsResponse.Item toItem(Notification notification);
+
+    /** 엔티티.relatedId 없을 때 payload.relatedId로 폴백 */
+    default Long resolveRelatedId(Notification n) {
+        if (n.getRelatedId() != null) return n.getRelatedId();
+        Map<String, Object> p = n.getPayload();
+        if (p == null) return null;
+        Object v = p.get("relatedId");
+        if (v instanceof Number num) return num.longValue();
+        return null;
+    }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/mapper/NotificationWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/mapper/NotificationWebMapper.java
@@ -3,20 +3,23 @@ package org.devkor.apu.saerok_server.domain.notification.mapper;
 import org.devkor.apu.saerok_server.domain.notification.api.dto.response.GetNotificationsResponse;
 import org.devkor.apu.saerok_server.domain.notification.api.dto.response.GetUnreadCountResponse;
 import org.devkor.apu.saerok_server.domain.notification.core.entity.Notification;
+import org.devkor.apu.saerok_server.domain.user.core.service.UserProfileImageUrlService;
 import org.devkor.apu.saerok_server.global.shared.util.OffsetDateTimeLocalizer;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import java.util.List;
-import java.util.Map;
 
-@Mapper(componentModel = "spring",
-        imports = OffsetDateTimeLocalizer.class)
+@Mapper(componentModel = "spring", imports = OffsetDateTimeLocalizer.class)
 public interface NotificationWebMapper {
 
-    default GetNotificationsResponse toGetNotificationsResponse(List<Notification> notifications) {
+    default GetNotificationsResponse toGetNotificationsResponse(
+            List<Notification> notifications,
+            @Context UserProfileImageUrlService userProfileImageUrlService
+    ) {
         List<GetNotificationsResponse.Item> items = notifications.stream()
-                .map(this::toItem)
+                .map(n -> toItem(n, userProfileImageUrlService))
                 .toList();
         return new GetNotificationsResponse(items);
     }
@@ -25,8 +28,13 @@ public interface NotificationWebMapper {
 
     @Mapping(target = "actorId", source = "actor.id")
     @Mapping(target = "actorNickname", source = "actor.nickname")
-    @Mapping(target = "createdAt", expression = "java(OffsetDateTimeLocalizer.toSeoulLocalDateTime(notification.getCreatedAt()))")
+    @Mapping(target = "actorProfileImageUrl",
+            expression = "java(notification.getActor() == null ? null : userProfileImageUrlService.getProfileImageUrlFor(notification.getActor()))")
+    @Mapping(target = "createdAt",
+            expression = "java(OffsetDateTimeLocalizer.toSeoulLocalDateTime(notification.getCreatedAt()))")
     @Mapping(target = "payload", expression = "java(notification.getPayload())")
-    GetNotificationsResponse.Item toItem(Notification notification);
-
+    GetNotificationsResponse.Item toItem(
+            Notification notification,
+            @Context UserProfileImageUrlService userProfileImageUrlService
+    );
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/mapper/NotificationWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/mapper/NotificationWebMapper.java
@@ -27,16 +27,6 @@ public interface NotificationWebMapper {
     @Mapping(target = "actorNickname", source = "actor.nickname")
     @Mapping(target = "createdAt", expression = "java(OffsetDateTimeLocalizer.toSeoulLocalDateTime(notification.getCreatedAt()))")
     @Mapping(target = "payload", expression = "java(notification.getPayload())")
-    @Mapping(target = "relatedId", expression = "java(resolveRelatedId(notification))")
     GetNotificationsResponse.Item toItem(Notification notification);
 
-    /** 엔티티.relatedId 없을 때 payload.relatedId로 폴백 */
-    default Long resolveRelatedId(Notification n) {
-        if (n.getRelatedId() != null) return n.getRelatedId();
-        Map<String, Object> p = n.getPayload();
-        if (p == null) return null;
-        Object v = p.get("relatedId");
-        if (v instanceof Number num) return num.longValue();
-        return null;
-    }
 }

--- a/src/main/resources/db/migration/V50__add_payload_to_noti_and_migrate_related_id.sql
+++ b/src/main/resources/db/migration/V50__add_payload_to_noti_and_migrate_related_id.sql
@@ -1,0 +1,8 @@
+-- 1) payload(jsonb) 컬럼 추가 (기본값은 빈 오브젝트)
+ALTER TABLE notification
+    ADD COLUMN IF NOT EXISTS payload JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- 2) 기존 related_id 값을 payload.relatedId로 이관
+UPDATE notification
+SET payload = jsonb_build_object('relatedId', related_id)
+WHERE related_id IS NOT NULL;

--- a/src/main/resources/db/migration/V51__delete_related_id_from_noti.sql
+++ b/src/main/resources/db/migration/V51__delete_related_id_from_noti.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notification DROP COLUMN IF EXISTS related_id;


### PR DESCRIPTION
## 📝 요약(Summary)

Closes #134 

알림 목록 응답에서 **컬렉션 이미지 URL**과 **액터 프로필 이미지 URL**도 같이 달아달라는 FE 요구사항에 대응했습니다.

이를 반영하면서 구조를 손봤습니다:

* notification 테이블에서 `related_id` 칼럼을 제거하고, 알림별 메타데이터는 **payload(jsonb)** 로 일원화했어요.
* `payload`에는 TargetType에 맞는 키(`collectionId`, `collectionImageUrl`)를 넣고, 응답에는 `actorProfileImageUrl`도 추가했어요.
* NotifyActionDSL은 **여전히 외부 Repository/Service를 몰라요**. 필요한 메타데이터는 밖에서 모아서(enrich) DSL에 건네주고, NotifyActionDSL은 누군가의 어떤 행동이 일어났다는 것을 선언하고 NotificationPublisher에게 알려주는 일에 집중해요.

👉 결과적으로, **프론트가 요청한 이미지 정보 제공**을 충족하면서, **앞으로 알림별 다양한 메타데이터 확장**에도 대비한 구조로 바뀌었습니다.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.