### PR TITLE
feat(): 푸쉬 메시지에 알림 id 필드 추가

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/store/InAppNotificationWriter.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/assembly/store/InAppNotificationWriter.java
@@ -21,7 +21,7 @@ public class InAppNotificationWriter {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
-    public void save(NotificationPayload payload, String deepLink) {
+    public Long save(NotificationPayload payload, String deepLink) {
         if (!(payload instanceof ActionNotificationPayload a)) {
             throw new IllegalArgumentException("Unsupported payload: " + payload.getClass());
         }
@@ -47,5 +47,7 @@ public class InAppNotificationWriter {
                 .build();
 
         notificationRepository.save(entity);
+        notificationRepository.flush();
+        return entity.getId();
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/dto/PushMessageCommand.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/dto/PushMessageCommand.java
@@ -21,9 +21,12 @@ public record PushMessageCommand(
         String deepLink,
 
         @Schema(description = "읽지 않은 알림 수 (APNs 배지용)", example = "5")
-        int unreadCount
+        int unreadCount,
+
+        @Schema(description = "알림 ID", example = "12")
+        Long notificationId
 ) {
-    public static PushMessageCommand createPushMessageCommand(String title, String body, String notificationType, Long relatedId, String deepLink, int unreadCount) {
-        return new PushMessageCommand(title, body, notificationType, relatedId, deepLink, unreadCount);
+    public static PushMessageCommand createPushMessageCommand(String title, String body, String notificationType, Long relatedId, String deepLink, int unreadCount, Long notificationId) {
+        return new PushMessageCommand(title, body, notificationType, relatedId, deepLink, unreadCount, notificationId);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotificationPublisher.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/facade/NotificationPublisher.java
@@ -36,7 +36,7 @@ public class NotificationPublisher {
 
         RenderedMessage renderedMessage = renderer.render(payload);
         String deepLink = deepLinkResolver.resolve(target);
-        inAppWriter.save(payload, deepLink);
+        Long notificationId = inAppWriter.save(payload, deepLink);
 
         int unread = notificationRepository.countUnreadByUserId(payload.recipientId()).intValue();
 
@@ -47,7 +47,7 @@ public class NotificationPublisher {
         String typeString = NotificationTypeResolver.from(a.subject(), a.action()).name();
 
         PushMessageCommand cmd = PushMessageCommand.createPushMessageCommand(
-                renderedMessage.pushTitle(), renderedMessage.pushBody(), typeString, target.id(), deepLink, unread
+                renderedMessage.pushTitle(), renderedMessage.pushBody(), typeString, target.id(), deepLink, unread, notificationId
         );
 
         pushGateway.sendToUser(a.recipientId(), a.subject(), a.action(), cmd);

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/core/repository/NotificationRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/core/repository/NotificationRepository.java
@@ -19,6 +19,7 @@ public class NotificationRepository {
     }
 
     public void save(Notification notification) { em.persist(notification); }
+    public void flush() { em.flush(); }
 
     public void remove(Notification notification) { em.remove(notification); }
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/infra/fcm/FcmMessageClient.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/infra/fcm/FcmMessageClient.java
@@ -47,6 +47,7 @@ public class FcmMessageClient {
         if (cmd.notificationType() != null) data.put("type", cmd.notificationType());
         if (cmd.relatedId() != null)       data.put("relatedId", cmd.relatedId().toString());
         if (cmd.deepLink() != null)        data.put("deeplink", cmd.deepLink());
+        if (cmd.notificationId() != null)  data.put("notificationId", cmd.notificationId().toString());
 
         int badge = Math.max(0, Math.min(cmd.unreadCount(), 999));
         ApnsConfig apns = ApnsConfig.builder()


### PR DESCRIPTION
## 📝 요약(Summary)

푸쉬 알림을 눌렀을 때 곧바로 읽음 처리를 할 수 있도록 알림 id 필드를 추가했습니다. (프론트 요청사항)

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.