### PR TITLE
feat(): 알림 삭제에도 사일런트 푸쉬 추가

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/NotificationCommandService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/notification/application/NotificationCommandService.java
@@ -52,10 +52,14 @@ public class NotificationCommandService {
         }
 
         notificationRepository.remove(notification);
+
+        pushGateway.sendSilentBadgeUpdate(userId, notificationRepository.countUnreadByUserId(userId).intValue());
     }
 
     public void deleteAllNotifications(Long userId) {
         userRepository.findById(userId).orElseThrow(() -> new NotFoundException("존재하지 않는 사용자 id예요"));
         notificationRepository.deleteByUserId(userId);
+
+        pushGateway.sendSilentBadgeUpdate(userId, notificationRepository.countUnreadByUserId(userId).intValue());
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

알림 삭제 시에도 사일런트 푸쉬가 발송되도록 했습니다.

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.