### PR TITLE
fix: 운영 workflow 배포 실패 원인 해결

### DIFF
--- a/.github/workflows/deploy-to-prod-ec2.yml
+++ b/.github/workflows/deploy-to-prod-ec2.yml
@@ -80,7 +80,7 @@ jobs:
             KAKAO_REDIRECT_URI="${{ secrets.KAKAO_REDIRECT_URI }}" \
             KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \
             KMS_KEY_ID="${{ secrets.KMS_KEY_ID }}" \
-            FIREBASE_ADMIN_KEY="${{ secrets.FIREBASE_ADMIN_KEY }}" \   
+            FIREBASE_ADMIN_KEY="${{ secrets.FIREBASE_ADMIN_KEY }}" \
             nohup java -Duser.timezone=Asia/Seoul -jar $JAR_NAME --spring.profiles.active=prod > app.log 2>&1 &
             
             echo "✅ 배포 완료"


### PR DESCRIPTION
줄 끝 \ 뒤의 공백 때문에 실패한 것으로 보임..

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.