### PR TITLE
chore: nibrUrl이 null이면 대신 빈 문자열로 응답

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/mapper/BirdProfileViewMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/dex/bird/query/mapper/BirdProfileViewMapper.java
@@ -18,6 +18,8 @@ public abstract class BirdProfileViewMapper {
     private ImageDomainService imageDomainService;
 
     @Mapping(target = "images.s3Url", ignore = true)
+    @Mapping(target = "nibrUrl", expression = "java(birdProfileView.getNibrUrl() == null ? \"\" : birdProfileView.getNibrUrl())")
+    // TODO: 프론트에서 nibrUrl null 처리가 되면, 이 nibrUrl 임시 처리(null 대신 빈 문자열)를 지운다.
     public abstract BirdFullSyncResponse.BirdProfileItem toDto(BirdProfileView birdProfileView);
 
     @AfterMapping


### PR DESCRIPTION
## 📝 요약(Summary)

현재 프론트의 도감 데이터 처리 로직과 호환성을 맞추기 위한 임시 조치. 추후 프론트에서 nibrUrl null 처리 대응이 되면 지우도록 TODO 주석 달았음

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.