### PR TITLE
feat: 관리자 카카오 로그인 지원

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/AuthController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/AuthController.java
@@ -102,7 +102,13 @@ public class AuthController {
             HttpServletRequest httpServletRequest
     ) {
         ClientInfo clientInfo = clientInfoExtractor.extract(httpServletRequest);
-        return kakaoAuthService.authenticate(request.getAuthorizationCode(), request.getAccessToken(), clientInfo);
+        // channel(요청 주체)에 따라 redirect_uri를 선택적으로 매핑
+        return kakaoAuthService.authenticate(
+                request.getAuthorizationCode(),
+                request.getAccessToken(),
+                request.getChannel(),
+                clientInfo
+        );
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/api/dto/request/KakaoLoginRequest.java
@@ -12,4 +12,6 @@ public class KakaoLoginRequest {
     @Schema(description = "액세스 토큰")
     private String accessToken;
 
+    @Schema(description = "로그인 요청 주체 채널 (예: 'admin', 'user' 등)")
+    private String channel;
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/AbstractSocialAuthService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/AbstractSocialAuthService.java
@@ -33,9 +33,15 @@ public abstract class AbstractSocialAuthService {
 
     protected abstract SocialAuthClient client();
 
+    /** 기존 기본 흐름(redirect_uri 고정) */
     public ResponseEntity<AccessTokenResponse> authenticate(String authorizationCode, String accessToken, ClientInfo ci) {
-
         SocialUserInfo userInfo = client().fetch(authorizationCode, accessToken);
+        return authenticateWithUserInfo(userInfo, ci);
+    }
+
+    /** 공급자별 커스텀 흐름(예: redirect_uri 동적 선택)에서도 재사용 가능한 공통 후처리 */
+    protected ResponseEntity<AccessTokenResponse> authenticateWithUserInfo(SocialUserInfo userInfo, ClientInfo ci) {
+
         SocialProviderType provider = client().provider();
         log.info("사용자 인증 - provider: {}, sub: {}, email: {}", provider, userInfo.sub(), userInfo.email());
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/KakaoAuthService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/KakaoAuthService.java
@@ -8,7 +8,10 @@ import org.devkor.apu.saerok_server.domain.auth.core.service.UserProvisioningSer
 import org.devkor.apu.saerok_server.domain.auth.infra.KakaoAuthClient;
 import org.devkor.apu.saerok_server.domain.auth.infra.KakaoRedirectUriResolver;
 import org.devkor.apu.saerok_server.domain.auth.infra.SocialAuthClient;
+import org.devkor.apu.saerok_server.domain.user.core.entity.UserRoleType;
+import org.devkor.apu.saerok_server.domain.user.core.repository.UserRoleRepository;
 import org.devkor.apu.saerok_server.global.security.crypto.DataCryptoService;
+import org.devkor.apu.saerok_server.global.shared.exception.ForbiddenException;
 import org.devkor.apu.saerok_server.global.shared.util.dto.ClientInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -19,17 +22,24 @@ public class KakaoAuthService extends AbstractSocialAuthService {
     private final KakaoAuthClient kakaoAuthClient;
     private final KakaoRedirectUriResolver redirectUriResolver;
 
+    // admin 채널 권한 확인을 위해 필요
+    private final SocialAuthRepository socialAuthRepository;
+    private final UserRoleRepository userRoleRepository;
+
     public KakaoAuthService(
             SocialAuthRepository socialAuthRepository,
             AuthTokenFacade authTokenFacade,
             UserProvisioningService userProvisioningService,
             DataCryptoService dataCryptoService,
             KakaoAuthClient kakaoAuthClient,
-            KakaoRedirectUriResolver redirectUriResolver
+            KakaoRedirectUriResolver redirectUriResolver,
+            UserRoleRepository userRoleRepository
     ) {
         super(socialAuthRepository, authTokenFacade, userProvisioningService, dataCryptoService);
         this.kakaoAuthClient = kakaoAuthClient;
         this.redirectUriResolver = redirectUriResolver;
+        this.socialAuthRepository = socialAuthRepository;
+        this.userRoleRepository = userRoleRepository;
     }
 
     @Override
@@ -41,6 +51,7 @@ public class KakaoAuthService extends AbstractSocialAuthService {
      * channel(요청 주체)에 따라 허용된 redirect_uri를 선택해 Kakao 토큰 교환을 수행.
      * - authorizationCode 경로에서만 redirect_uri가 사용됨
      * - accessToken 경로는 기존 처리와 동일
+     * - channel이 "admin"이면 해당 계정이 ADMIN 권한을 가지고 있는지 선확인(없으면 403)
      */
     public ResponseEntity<AccessTokenResponse> authenticate(
             String authorizationCode,
@@ -55,6 +66,24 @@ public class KakaoAuthService extends AbstractSocialAuthService {
         } else {
             userInfo = kakaoAuthClient.fetch(null, accessToken);
         }
+
+        // ===== ADMIN 채널 권한 검사 =====
+        if ("admin".equalsIgnoreCase(channel)) {
+            // 기존 소셜 링크가 없으면 관리자 로그인 불가
+            var link = socialAuthRepository
+                    .findByProviderAndProviderUserId(kakaoAuthClient.provider(), userInfo.sub())
+                    .orElseThrow(() ->
+                            new ForbiddenException("관리자 권한이 없는 계정입니다 (미등록 계정)"));
+
+            var hasAdminRole = userRoleRepository.findByUser(link.getUser()).stream()
+                    .anyMatch(ur -> ur.getRole() == UserRoleType.ADMIN);
+
+            if (!hasAdminRole) {
+                throw new ForbiddenException("관리자 권한이 없는 계정입니다");
+            }
+        }
+        // =============================
+
         return authenticateWithUserInfo(userInfo, ci);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/KakaoAuthService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/KakaoAuthService.java
@@ -1,31 +1,60 @@
 package org.devkor.apu.saerok_server.domain.auth.application;
 
+import org.devkor.apu.saerok_server.domain.auth.api.dto.response.AccessTokenResponse;
 import org.devkor.apu.saerok_server.domain.auth.application.facade.AuthTokenFacade;
+import org.devkor.apu.saerok_server.domain.auth.core.dto.SocialUserInfo;
 import org.devkor.apu.saerok_server.domain.auth.core.repository.SocialAuthRepository;
 import org.devkor.apu.saerok_server.domain.auth.core.service.UserProvisioningService;
 import org.devkor.apu.saerok_server.domain.auth.infra.KakaoAuthClient;
+import org.devkor.apu.saerok_server.domain.auth.infra.KakaoRedirectUriResolver;
 import org.devkor.apu.saerok_server.domain.auth.infra.SocialAuthClient;
 import org.devkor.apu.saerok_server.global.security.crypto.DataCryptoService;
+import org.devkor.apu.saerok_server.global.shared.util.dto.ClientInfo;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
 public class KakaoAuthService extends AbstractSocialAuthService {
 
     private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoRedirectUriResolver redirectUriResolver;
 
     public KakaoAuthService(
             SocialAuthRepository socialAuthRepository,
             AuthTokenFacade authTokenFacade,
             UserProvisioningService userProvisioningService,
             DataCryptoService dataCryptoService,
-            KakaoAuthClient kakaoAuthClient
+            KakaoAuthClient kakaoAuthClient,
+            KakaoRedirectUriResolver redirectUriResolver
     ) {
         super(socialAuthRepository, authTokenFacade, userProvisioningService, dataCryptoService);
         this.kakaoAuthClient = kakaoAuthClient;
+        this.redirectUriResolver = redirectUriResolver;
     }
 
     @Override
     protected SocialAuthClient client() {
         return kakaoAuthClient;
+    }
+
+    /**
+     * channel(요청 주체)에 따라 허용된 redirect_uri를 선택해 Kakao 토큰 교환을 수행.
+     * - authorizationCode 경로에서만 redirect_uri가 사용됨
+     * - accessToken 경로는 기존 처리와 동일
+     */
+    public ResponseEntity<AccessTokenResponse> authenticate(
+            String authorizationCode,
+            String accessToken,
+            String channel,
+            ClientInfo ci
+    ) {
+        SocialUserInfo userInfo;
+        if (authorizationCode != null) {
+            String redirectUri = redirectUriResolver.resolve(channel);
+            userInfo = kakaoAuthClient.fetchWithRedirect(authorizationCode, null, redirectUri);
+        } else {
+            userInfo = kakaoAuthClient.fetch(null, accessToken);
+        }
+        return authenticateWithUserInfo(userInfo, ci);
     }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoRedirectUriResolver.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoRedirectUriResolver.java
@@ -1,0 +1,33 @@
+package org.devkor.apu.saerok_server.domain.auth.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.devkor.apu.saerok_server.global.core.properties.KakaoRedirectRoutingProperties;
+import org.devkor.apu.saerok_server.global.shared.exception.UnauthorizedException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoRedirectUriResolver {
+
+    private final KakaoRedirectRoutingProperties props;
+
+    /**
+     * 채널 문자열에 따라 redirect_uri를 선택한다.
+     * - channel 누락/공백: default 사용 (설정되어 있어야 함)
+     * - 등록되지 않은 channel: 401
+     */
+    public String resolve(String channel) {
+        if (channel == null || channel.isBlank()) {
+            String def = props.getDefaultRedirectUri();
+            if (def == null || def.isBlank()) {
+                throw new UnauthorizedException("로그인 채널이 없고 기본 redirect URI도 설정되지 않았어요");
+            }
+            return def;
+        }
+        String uri = props.getChannels().get(channel);
+        if (uri == null || uri.isBlank()) {
+            throw new UnauthorizedException("지원하지 않는 로그인 채널이에요: " + channel);
+        }
+        return uri;
+    }
+}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/UserRoleType.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/entity/UserRoleType.java
@@ -3,5 +3,6 @@ package org.devkor.apu.saerok_server.domain.user.core.entity;
 public enum UserRoleType {
 
     USER,
-    ADMIN
+    ADMIN_VIEWER,
+    ADMIN_EDITOR
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/core/properties/KakaoRedirectRoutingProperties.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/core/properties/KakaoRedirectRoutingProperties.java
@@ -1,0 +1,23 @@
+package org.devkor.apu.saerok_server.global.core.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 채널별로 허용된 Kakao redirect_uri를 보관하는 프로퍼티.
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "oauth.kakao.redirect-routing")
+public class KakaoRedirectRoutingProperties {
+
+    /** channel이 없을 때 사용할 기본 redirect_uri */
+    private String defaultRedirectUri;
+
+    /** channel → redirect_uri */
+    private Map<String, String> channels = new HashMap<>();
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,6 +49,13 @@ kakao:
   client-secret: ${KAKAO_CLIENT_SECRET}
   admin-key: ${KAKAO_ADMIN_KEY}
 
+oauth:
+  kakao:
+    redirect-routing:
+      default-redirect-uri: ${KAKAO_REDIRECT_URI}
+      channels:
+        admin: ${KAKAO_REDIRECT_URI_ADMIN}
+
 app:
   cookie:
     secure: false

--- a/up.sh
+++ b/up.sh
@@ -8,4 +8,4 @@ docker compose \
   -p saerok-be \
   -f deploy/docker-compose.yml \
   -f deploy/docker-compose.override.yml \
-  up -d
+  up --build -d


### PR DESCRIPTION
## 📝 요약(Summary)

 - 관리자 카카오 로그인을 위한 서비스 서버 지원을 추가했습니다
 - 기존 ADMIN 권한을 ADMIN_VIEWER, ADMIN_EDITOR 권한으로 세분화했습니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.