### PR TITLE
fix: 빼먹은 환경변수 추가

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2-docker.yml
+++ b/.github/workflows/deploy-to-dev-ec2-docker.yml
@@ -109,6 +109,7 @@ jobs:
             add_kv KAKAO_ADMIN_KEY "${{ secrets.KAKAO_ADMIN_KEY }}"
             add_kv KAKAO_CLIENT_ID "${{ secrets.KAKAO_CLIENT_ID }}"
             add_kv KAKAO_REDIRECT_URI "${{ secrets.KAKAO_REDIRECT_URI }}"
+            add_kv KAKAO_REDIRECT_URI_ADMIN "${{ secrets.KAKAO_REDIRECT_URI_ADMIN }}"
             add_kv KAKAO_CLIENT_SECRET "${{ secrets.KAKAO_CLIENT_SECRET }}"
             add_kv KMS_KEY_ID "${{ secrets.KMS_KEY_ID }}"
 


### PR DESCRIPTION
## 📝 요약(Summary)

KAKAO_REDIRECT_URI_ADMIN 키 추가로 누락된 환경변수 설정 문제 수정.
개발 환경에서 Kakao Admin 관련 설정 누락 방지.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.