### PR TITLE
fix: ADMIN_VIEWER 권한을 신고 무시 API에서 제거

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/admin/api/AdminReportController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/admin/api/AdminReportController.java
@@ -123,10 +123,10 @@ public class AdminReportController {
 
     @PostMapping("/collections/{reportId}/ignore")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PreAuthorize("hasAnyRole('ADMIN_VIEWER','ADMIN_EDITOR')")
+    @PreAuthorize("hasAnyRole('ADMIN_EDITOR')")
     @Operation(
             summary = "새록 신고 무시(신고 삭제)",
-            description = "관리자 권한 필요: ADMIN_VIEWER 또는 ADMIN_EDITOR",
+            description = "관리자 권한 필요: ADMIN_EDITOR",
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "무시 처리 성공(신고 삭제)"),
@@ -142,10 +142,10 @@ public class AdminReportController {
 
     @PostMapping("/comments/{reportId}/ignore")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PreAuthorize("hasAnyRole('ADMIN_VIEWER','ADMIN_EDITOR')")
+    @PreAuthorize("hasAnyRole('ADMIN_EDITOR')")
     @Operation(
             summary = "댓글 신고 무시(신고 삭제)",
-            description = "관리자 권한 필요: ADMIN_VIEWER 또는 ADMIN_EDITOR",
+            description = "관리자 권한 필요: ADMIN_EDITOR",
             security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(responseCode = "204", description = "무시 처리 성공(신고 삭제)"),


### PR DESCRIPTION
## 📝 요약(Summary)

ADMIN_VIEWER 역할이 불필요하게 지정된 API 수정.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.