### PR TITLE
feat: 신고 삭제 시 사유 전달 및 감사 로그 확장

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/admin/api/dto/request/AdminDeleteReasonRequest.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/admin/api/dto/request/AdminDeleteReasonRequest.java
@@ -1,0 +1,9 @@
+package org.devkor.apu.saerok_server.domain.admin.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 삭제 사유 요청 DTO")
+public record AdminDeleteReasonRequest(
+        @Schema(description = "삭제 사유", example = "욕설/혐오 발언 포함으로 삭제")
+        String reason
+) { }

--- a/src/test/java/org/devkor/apu/saerok_server/domain/admin/application/AdminReportCommandServiceTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/admin/application/AdminReportCommandServiceTest.java
@@ -1,9 +1,7 @@
-// ./src/test/java/org/devkor/apu/saerok_server/domain/admin/application/AdminReportCommandServiceTest.java
 package org.devkor.apu.saerok_server.domain.admin.application;
 
 import org.devkor.apu.saerok_server.domain.admin.core.entity.AdminAuditAction;
 import org.devkor.apu.saerok_server.domain.admin.core.entity.AdminAuditLog;
-import org.devkor.apu.saerok_server.domain.admin.core.entity.AdminAuditTargetType;
 import org.devkor.apu.saerok_server.domain.admin.core.repository.AdminAuditLogRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollectionComment;
@@ -35,24 +33,20 @@ import static org.mockito.Mockito.*;
 class AdminReportCommandServiceTest {
 
     private static final long ADMIN_ID = 999L;
+    private static final String REASON = "운영정책 위반(욕설)";
 
     @InjectMocks
     AdminReportCommandService sut;
 
-    /* repos */
     @Mock CollectionReportRepository         collectionReportRepository;
     @Mock CollectionCommentReportRepository  commentReportRepository;
     @Mock CollectionRepository               collectionRepository;
     @Mock CollectionCommentRepository        commentRepository;
     @Mock CollectionImageRepository          collectionImageRepository;
-
     @Mock ImageService imageService;
 
-    /* 새로 추가된 의존성 (감사 로그, 관리자 계정 조회) */
     @Mock AdminAuditLogRepository adminAuditLogRepository;
     @Mock UserRepository          userRepository;
-
-    /* ---------------- helpers ---------------- */
 
     private static User user(long id) {
         User u = new User();
@@ -60,17 +54,19 @@ class AdminReportCommandServiceTest {
         return u;
     }
 
-    private static UserBirdCollection collection(long id) {
+    private static UserBirdCollection collection(long id, String note) {
         UserBirdCollection c = new UserBirdCollection();
         ReflectionTestUtils.setField(c, "id", id);
+        c.setNote(note);
         return c;
     }
+
+    private static UserBirdCollection collection(long id) { return collection(id, null); }
 
     private static UserBirdCollectionReport collectionReport(long reportId, long collectionId, long reporterId, long reportedId) {
         User reporter = user(reporterId);
         User reported = user(reportedId);
         UserBirdCollection col = collection(collectionId);
-
         UserBirdCollectionReport rep = UserBirdCollectionReport.of(reporter, reported, col);
         ReflectionTestUtils.setField(rep, "id", reportId);
         return rep;
@@ -82,7 +78,6 @@ class AdminReportCommandServiceTest {
         UserBirdCollection col = collection(collectionId);
         UserBirdCollectionComment cm = UserBirdCollectionComment.of(reported, col, content);
         ReflectionTestUtils.setField(cm, "id", commentId);
-
         UserBirdCollectionCommentReport rep = UserBirdCollectionCommentReport.of(reporter, reported, cm);
         ReflectionTestUtils.setField(rep, "id", reportId);
         return rep;
@@ -91,8 +86,6 @@ class AdminReportCommandServiceTest {
     private void stubAdminUser() {
         when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(user(ADMIN_ID)));
     }
-
-    /* -------------------- tests -------------------- */
 
     @Test
     @DisplayName("ignoreCollectionReport: 성공 → 신고 삭제 + 감사 로그 기록")
@@ -111,28 +104,18 @@ class AdminReportCommandServiceTest {
         verify(adminAuditLogRepository).save(cap.capture());
 
         AdminAuditLog log = cap.getValue();
-        assertThat(log.getAdmin().getId()).isEqualTo(ADMIN_ID);
         assertThat(log.getAction()).isEqualTo(AdminAuditAction.REPORT_IGNORED);
-        assertThat(log.getTargetType()).isEqualTo(AdminAuditTargetType.REPORT_COLLECTION);
-        assertThat(log.getTargetId()).isEqualTo(reportId);
-        assertThat(log.getReportId()).isEqualTo(reportId);
-
         Map<String, Object> md = log.getMetadata();
         assertThat(md.get("collectionId")).isEqualTo(100L);
-        assertThat(md.get("reporterId")).isEqualTo(10L);
-        assertThat(md.get("reportedUserId")).isEqualTo(20L);
     }
 
     @Test
-    @DisplayName("ignoreCollectionReport: 없음 → 404 (행위자 조회/감사 저장 호출 안 함)")
+    @DisplayName("ignoreCollectionReport: 없음 → 404")
     void ignoreCollectionReport_notFound() {
         long reportId = 9L;
         when(collectionReportRepository.findById(reportId)).thenReturn(Optional.of(collectionReport(reportId, 1L, 2L, 3L)));
         when(collectionReportRepository.deleteById(reportId)).thenReturn(false);
-
-        assertThatThrownBy(() -> sut.ignoreCollectionReport(ADMIN_ID, reportId))
-                .isInstanceOf(NotFoundException.class);
-
+        assertThatThrownBy(() -> sut.ignoreCollectionReport(ADMIN_ID, reportId)).isInstanceOf(NotFoundException.class);
         verifyNoInteractions(userRepository, adminAuditLogRepository);
     }
 
@@ -153,50 +136,37 @@ class AdminReportCommandServiceTest {
         verify(adminAuditLogRepository).save(cap.capture());
 
         AdminAuditLog log = cap.getValue();
-        assertThat(log.getAdmin().getId()).isEqualTo(ADMIN_ID);
         assertThat(log.getAction()).isEqualTo(AdminAuditAction.REPORT_IGNORED);
-        assertThat(log.getTargetType()).isEqualTo(AdminAuditTargetType.REPORT_COMMENT);
-        assertThat(log.getTargetId()).isEqualTo(reportId);
-        assertThat(log.getReportId()).isEqualTo(reportId);
-
         Map<String, Object> md = log.getMetadata();
         assertThat(md.get("commentId")).isEqualTo(200L);
-        assertThat(md.get("collectionId")).isEqualTo(10L);
-        assertThat(md.get("reporterId")).isEqualTo(11L);
-        assertThat(md.get("reportedUserId")).isEqualTo(21L);
         assertThat(md.get("commentContentSnapshot")).isEqualTo("악성 댓글");
     }
 
     @Test
-    @DisplayName("ignoreCommentReport: 없음 → 404 (행위자 조회/감사 저장 호출 안 함)")
+    @DisplayName("ignoreCommentReport: 없음 → 404")
     void ignoreCommentReport_notFound() {
         long reportId = 8L;
         when(commentReportRepository.findById(reportId)).thenReturn(Optional.of(commentReport(reportId, 1L, 1L, 1L, 1L, "x")));
         when(commentReportRepository.deleteById(reportId)).thenReturn(false);
-
-        assertThatThrownBy(() -> sut.ignoreCommentReport(ADMIN_ID, reportId))
-                .isInstanceOf(NotFoundException.class);
-
+        assertThatThrownBy(() -> sut.ignoreCommentReport(ADMIN_ID, reportId)).isInstanceOf(NotFoundException.class);
         verifyNoInteractions(userRepository, adminAuditLogRepository);
     }
 
     @Test
-    @DisplayName("deleteCollectionByReport: 신고된 새록 삭제 + 신고 정리 + S3 삭제 + 감사 로그 기록")
+    @DisplayName("deleteCollectionByReport: 삭제 + 신고 정리 + S3 삭제 + 감사 로그(reason, note 스냅샷)")
     void deleteCollectionByReport_success() {
-        long reportId = 50L;
-        long colId = 100L;
-
-        UserBirdCollection col = collection(colId);
+        long reportId = 50L; long colId = 100L;
         var rep = collectionReport(reportId, colId, 1L, 2L);
-
         when(collectionReportRepository.findById(reportId)).thenReturn(Optional.of(rep));
         when(collectionImageRepository.findObjectKeysByCollectionId(colId)).thenReturn(List.of("k1", "k2"));
+
+        UserBirdCollection col = collection(colId, "노트 스냅샷");
         when(collectionRepository.findById(colId)).thenReturn(Optional.of(col));
         stubAdminUser();
 
         ArgumentCaptor<AdminAuditLog> cap = ArgumentCaptor.forClass(AdminAuditLog.class);
 
-        sut.deleteCollectionByReport(ADMIN_ID, reportId);
+        sut.deleteCollectionByReport(ADMIN_ID, reportId, REASON);
 
         verify(collectionReportRepository).deleteByCollectionId(colId);
         verify(commentReportRepository).deleteByCollectionId(colId);
@@ -205,75 +175,52 @@ class AdminReportCommandServiceTest {
         verify(adminAuditLogRepository).save(cap.capture());
 
         AdminAuditLog log = cap.getValue();
-        assertThat(log.getAdmin().getId()).isEqualTo(ADMIN_ID);
         assertThat(log.getAction()).isEqualTo(AdminAuditAction.COLLECTION_DELETED);
-        assertThat(log.getTargetType()).isEqualTo(AdminAuditTargetType.COLLECTION);
-        assertThat(log.getTargetId()).isEqualTo(colId);
-        assertThat(log.getReportId()).isEqualTo(reportId);
-
         Map<String, Object> md = log.getMetadata();
-        assertThat(md.get("reporterId")).isEqualTo(1L);
-        assertThat(md.get("reportedUserId")).isEqualTo(2L);
+        assertThat(md.get("reason")).isEqualTo(REASON);
+        assertThat(md.get("collectionNoteSnapshot")).isEqualTo("노트 스냅샷");
         assertThat(md.get("deletedImageObjectKeyCount")).isEqualTo(2);
     }
 
     @Test
-    @DisplayName("deleteCollectionByReport: 신고 없음 → 404 (행위자 조회/감사 저장 호출 안 함)")
+    @DisplayName("deleteCollectionByReport: 신고 없음 → 404")
     void deleteCollectionByReport_notFound() {
         when(collectionReportRepository.findById(404L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> sut.deleteCollectionByReport(ADMIN_ID, 404L))
-                .isInstanceOf(NotFoundException.class);
-
+        assertThatThrownBy(() -> sut.deleteCollectionByReport(ADMIN_ID, 404L, REASON)).isInstanceOf(NotFoundException.class);
         verifyNoInteractions(userRepository, adminAuditLogRepository, imageService);
     }
 
     @Test
-    @DisplayName("deleteCommentByReport: 신고된 댓글 삭제 + 신고 정리 + 감사 로그 기록")
+    @DisplayName("deleteCommentByReport: 삭제 + 신고 정리 + 감사 로그(reason 포함)")
     void deleteCommentByReport_success() {
-        long reportId = 70L;
-        long cmId = 900L;
-        long colId = 10L;
-
+        long reportId = 70L; long cmId = 900L; long colId = 10L;
+        var rep = commentReport(reportId, cmId, colId, 11L, 21L, "bye");
+        when(commentReportRepository.findById(reportId)).thenReturn(Optional.of(rep));
         UserBirdCollectionComment cm = UserBirdCollectionComment.of(user(21L), collection(colId), "bye");
         ReflectionTestUtils.setField(cm, "id", cmId);
-
-        var rep = commentReport(reportId, cmId, colId, 11L, 21L, "bye");
-
-        when(commentReportRepository.findById(reportId)).thenReturn(Optional.of(rep));
         when(commentRepository.findById(cmId)).thenReturn(Optional.of(cm));
         stubAdminUser();
 
         ArgumentCaptor<AdminAuditLog> cap = ArgumentCaptor.forClass(AdminAuditLog.class);
 
-        sut.deleteCommentByReport(ADMIN_ID, reportId);
+        sut.deleteCommentByReport(ADMIN_ID, reportId, REASON);
 
         verify(commentReportRepository).deleteByCommentId(cmId);
         verify(commentRepository).remove(cm);
         verify(adminAuditLogRepository).save(cap.capture());
 
         AdminAuditLog log = cap.getValue();
-        assertThat(log.getAdmin().getId()).isEqualTo(ADMIN_ID);
         assertThat(log.getAction()).isEqualTo(AdminAuditAction.COMMENT_DELETED);
-        assertThat(log.getTargetType()).isEqualTo(AdminAuditTargetType.COMMENT);
-        assertThat(log.getTargetId()).isEqualTo(cmId);
-        assertThat(log.getReportId()).isEqualTo(reportId);
-
         Map<String, Object> md = log.getMetadata();
-        assertThat(md.get("collectionId")).isEqualTo(colId);
-        assertThat(md.get("reporterId")).isEqualTo(11L);
-        assertThat(md.get("reportedUserId")).isEqualTo(21L);
+        assertThat(md.get("reason")).isEqualTo(REASON);
         assertThat(md.get("commentContentSnapshot")).isEqualTo("bye");
     }
 
     @Test
-    @DisplayName("deleteCommentByReport: 신고 없음 → 404 (행위자 조회/감사 저장 호출 안 함)")
+    @DisplayName("deleteCommentByReport: 신고 없음 → 404")
     void deleteCommentByReport_notFound() {
         when(commentReportRepository.findById(71L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> sut.deleteCommentByReport(ADMIN_ID, 71L))
-                .isInstanceOf(NotFoundException.class);
-
+        assertThatThrownBy(() -> sut.deleteCommentByReport(ADMIN_ID, 71L, REASON)).isInstanceOf(NotFoundException.class);
         verifyNoInteractions(userRepository, adminAuditLogRepository);
     }
 }


### PR DESCRIPTION

## 📝 요약(Summary)

신고된 새록/댓글 삭제 시 삭제 사유(reason) 입력을 요구하도록 변경.
감사 로그에 사유 및 새록 한줄평 스냅샷 메타데이터 추가.
관련 컨트롤러 및 서비스 로직 수정, DTO 추가.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.