### PR TITLE
feat: 어드민 로그인 문제 해결 및 재발 방지 장치 마련

### DIFF
--- a/.github/workflows/deploy-to-dev-ec2-docker.yml
+++ b/.github/workflows/deploy-to-dev-ec2-docker.yml
@@ -111,6 +111,7 @@ jobs:
             add_kv KAKAO_REDIRECT_URI "${{ secrets.KAKAO_REDIRECT_URI }}"
             add_kv KAKAO_REDIRECT_URI_ADMIN "${{ secrets.KAKAO_REDIRECT_URI_ADMIN }}"
             add_kv KAKAO_CLIENT_SECRET "${{ secrets.KAKAO_CLIENT_SECRET }}"
+            add_kv KAKAO_APP_ID "${{ secrets.KAKAO_APP_ID }}"
             add_kv KMS_KEY_ID "${{ secrets.KMS_KEY_ID }}"
 
             # 3) Pull & Recreate with resource limits from dev.yml

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoAuthClient.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoAuthClient.java
@@ -37,6 +37,9 @@ public class KakaoAuthClient implements SocialAuthClient {
         }
 
         if (accessToken != null) {
+            // ✅ 앱 키 섞임 방지: access_token_info 로 appId 검증
+            kakaoApiClient.validateAccessTokenAppId(accessToken);
+
             log.info("accessToken: {}", accessToken);
             KakaoUserInfoResponse userInfo = kakaoApiClient.fetchUserInfo(accessToken);
             log.info("email: {}", userInfo.getKakaoAccount().getEmail());

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/dto/KakaoAccessTokenInfoResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/dto/KakaoAccessTokenInfoResponse.java
@@ -1,0 +1,24 @@
+package org.devkor.apu.saerok_server.domain.auth.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * GET https://kapi.kakao.com/v1/user/access_token_info
+ * 로부터 받는 응답 모델.
+ */
+@Data
+public class KakaoAccessTokenInfoResponse {
+
+    /** 카카오 사용자 ID (sub) */
+    @JsonProperty("id")
+    private Long id;
+
+    /** 이 토큰을 발급한 Kakao 앱의 숫자 ID */
+    @JsonProperty("appId")
+    private Long appId;
+
+    /** 만료까지 남은 시간(ms). 카카오가 제공 */
+    @JsonProperty("expiresInMillis")
+    private Long expiresInMillis;
+}

--- a/src/main/java/org/devkor/apu/saerok_server/global/core/properties/KakaoProperties.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/core/properties/KakaoProperties.java
@@ -15,4 +15,11 @@ public class KakaoProperties {
     private String redirectUri;
     private String clientSecret;
     private String adminKey;
+
+    /**
+     * Kakao 앱의 고유 숫자 ID.
+     * /v1/user/access_token_info 응답의 appId와 일치해야 한다.
+     * application.yml 에서는 kakao.app-id 로 설정한다.
+     */
+    private Long appId;
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -60,6 +60,7 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
   client-secret: ${KAKAO_CLIENT_SECRET}
   admin-key: ${KAKAO_ADMIN_KEY}
+  app-id: ${KAKAO_APP_ID}
 
 oauth:
   kakao:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -48,6 +48,7 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
   client-secret: ${KAKAO_CLIENT_SECRET}
   admin-key: ${KAKAO_ADMIN_KEY}
+  app-id: ${KAKAO_APP_ID}
 
 oauth:
   kakao:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -63,6 +63,7 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
   client-secret: ${KAKAO_CLIENT_SECRET}
   admin-key: ${KAKAO_ADMIN_KEY}
+  app-id: ${KAKAO_APP_ID}
 
 oauth:
   kakao:


### PR DESCRIPTION
### 어드민 로그인 실패 원인 요약

* **핵심 요약**

  * 문제의 근본 원인은 iOS 테스트 앱의 설정 오류
  * 서버는 이를 사전에 걸러내지 못한 검증 부재에 책임이 있음
  * 현재는 서버에 앱 불일치 검증 로직을 추가하여 문제 재발을 방지함

### 원인 세부 사항

* **① 앱 설정 혼선으로 잘못된 토큰 발급**

  * iOS 테스트 앱이 운영용 앱의 설정을 잘못 참조함
  * 테스트 앱에서 카카오 로그인을 시도하면 운영용 앱으로 요청이 전달됨
  * 운영 앱 기준 `sub`(사용자 ID)가 발급되고, 그게 개발 서버로 넘어옴
  * 개발 서버(DB)에 운영 앱 기준 `sub` 값이 잘못 저장됨
  * 이후 "새록 어드민(개발/QA)"를 통해 로그인하면 테스트 앱 기준 `sub`가 발급되는데, 기존 DB에 등록된 운영 앱 기준 `sub`와 불일치함. 따라서 인증 실패 발생

* **② 서버 측 앱 검증 로직 부재**

  * 서버가 전달받은 access token의 `app_id`를 검증하지 않음
  * 테스트 앱이 운영 앱 토큰을 사용해도 서버에서 구분 불가
  * 이로 인해 문제 조기 탐지 및 차단 실패
  * 이번 PR에서는 `app_id` 불일치 시 즉시 401로 차단하도록 수정됨

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.