### PR TITLE
feat: 이메일 기반 사용자 중복 처리 로직 추가

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/user/core/repository/UserRepository.java
@@ -38,4 +38,11 @@ public class UserRepository {
                 .getResultStream()
                 .findFirst();
     }
+
+    public Optional<User> findByEmail(String email) {
+        return em.createQuery("SELECT u FROM User u WHERE u.email = :email AND u.deletedAt IS NULL", User.class)
+                .setParameter("email", email)
+                .getResultStream()
+                .findFirst();
+    }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

같은 이메일로 가입된 계정 존재 시 401 Unauthorized 에러 처리 추가.
기존 계정과 다른 provider sub가 연결된 경우 명시적 에러 메시지 제공.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.