### PR TITLE
fix: Kakao 인증 로그 출력 위치 변경

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/KakaoAuthService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/application/KakaoAuthService.java
@@ -1,5 +1,6 @@
 package org.devkor.apu.saerok_server.domain.auth.application;
 
+import lombok.extern.slf4j.Slf4j;
 import org.devkor.apu.saerok_server.domain.auth.api.dto.response.AccessTokenResponse;
 import org.devkor.apu.saerok_server.domain.auth.application.facade.AuthTokenFacade;
 import org.devkor.apu.saerok_server.domain.auth.core.dto.SocialUserInfo;
@@ -17,6 +18,7 @@ import org.devkor.apu.saerok_server.global.shared.util.dto.ClientInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class KakaoAuthService extends AbstractSocialAuthService {
 
@@ -68,6 +70,8 @@ public class KakaoAuthService extends AbstractSocialAuthService {
         } else {
             userInfo = kakaoAuthClient.fetch(null, accessToken);
         }
+
+        log.info("[fixlog] sub: {}, email: {}, channel: {}", userInfo.sub(), userInfo.email(), channel);
 
         // admin 채널 선권한 검증 (미보유시 관리자 시스템 로그인 불가)
         if ("admin".equalsIgnoreCase(channel)) {

--- a/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoAuthClient.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/auth/infra/KakaoAuthClient.java
@@ -39,7 +39,6 @@ public class KakaoAuthClient implements SocialAuthClient {
         if (accessToken != null) {
 
             KakaoUserInfoResponse userInfo = kakaoApiClient.fetchUserInfo(accessToken);
-            log.info("[fixlog] sub: {}, email: {}", userInfo.getId(), userInfo.getKakaoAccount().getEmail());
 
             // ✅ 앱 키 섞임 방지: access_token_info 로 appId 검증
             kakaoApiClient.validateAccessTokenAppId(accessToken);


### PR DESCRIPTION
## 📝 요약(Summary)

Kakao 인증 로그 출력 위치 변경

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.