### PR TITLE
feat(coll): 내 컬렉션 조회 및 주변 컬렉션 조회에서 썸네일 url도 반환

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
@@ -23,6 +23,9 @@ public class GetNearbyCollectionsResponse {
         @Schema(description = "이미지 URL", example = "https://cdn.example.com/collection-images/1.jpg")
         private String imageUrl;
 
+        @Schema(description = "썸네일 이미지 URL (320px 너비)", example = "https://cdn.example.com/thumbnails/abc.webp")
+        private String thumbnailImageUrl;
+
         @Schema(description = "새 한국어 이름", example = "까치")
         private String koreanName;
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/MyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/MyCollectionsResponse.java
@@ -17,6 +17,9 @@ public record MyCollectionsResponse(
         @Schema(description = "이미지 URL", example = "https://example.com/images/collection1.jpg")
         String imageUrl,
 
+        @Schema(description = "썸네일 이미지 URL (320px 너비)", example = "https://cdn.example.com/thumbnails/abc.webp")
+        String thumbnailImageUrl,
+
         @Schema(description = "새의 한국 이름", example = "까치")
         String koreanName,
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
@@ -77,15 +77,18 @@ public class CollectionQueryService {
 
         List<UserBirdCollection> collections = collectionRepository.findByUserId(userId);
         Map<Long, String> urlMap = collectionImageUrlService.getPrimaryImageUrlsFor(collections);
+        Map<Long, String> thumbnailUrlMap = collectionImageUrlService.getPrimaryImageThumbnailUrlsFor(collections);
 
         List<MyCollectionsResponse.Item> items = collections.stream()
                 .map(c -> {
                     String imageUrl = urlMap.get(c.getId());
+                    String thumbnailUrl = thumbnailUrlMap.get(c.getId());
                     long likeCount = collectionLikeRepository.countByCollectionId(c.getId());
                     long commentCount = collectionCommentRepository.countByCollectionId(c.getId());
                     return new MyCollectionsResponse.Item(
                             c.getId(),
                             imageUrl,
+                            thumbnailUrl,
                             c.getBird() == null ? null : c.getBird().getName().getKoreanName(),
                             likeCount,
                             commentCount
@@ -134,16 +137,18 @@ public class CollectionQueryService {
         List<UserBirdCollection> collections = collectionRepository.findNearby(refPoint, command.radiusMeters(), command.userId(), command.isMineOnly());
 
         Map<Long, String> urlMap = collectionImageUrlService.getPrimaryImageUrlsFor(collections);
+        Map<Long, String> thumbnailUrlMap = collectionImageUrlService.getPrimaryImageThumbnailUrlsFor(collections);
 
         List<GetNearbyCollectionsResponse.Item> items = collections.stream()
                 .map(collection -> {
                     String imageUrl = urlMap.get(collection.getId());
+                    String thumbnailUrl = thumbnailUrlMap.get(collection.getId());
                     long likeCount = collectionLikeRepository.countByCollectionId(collection.getId());
                     long commentCount = collectionCommentRepository.countByCollectionId(collection.getId());
                     boolean isLikedByMe = command.userId() != null && collectionLikeRepository.existsByUserIdAndCollectionId(command.userId(), collection.getId());
                     String userProfileImageUrl = userProfileImageUrlService.getProfileImageUrlFor(collection.getUser());
 
-                    return collectionWebMapper.toGetNearbyCollectionsResponseItem(collection, imageUrl, userProfileImageUrl, likeCount, commentCount, isLikedByMe);
+                    return collectionWebMapper.toGetNearbyCollectionsResponseItem(collection, imageUrl, thumbnailUrl, userProfileImageUrl, likeCount, commentCount, isLikedByMe);
                 })
                 .toList();
         // TODO: 많은 쿼리로 인한 성능 이슈 우려됨. 나중에 개선해야 할지도

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/helper/CollectionImageUrlService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/helper/CollectionImageUrlService.java
@@ -35,4 +35,17 @@ public class CollectionImageUrlService {
         return result;
     }
 
+    public Map<Long, String> getPrimaryImageThumbnailUrlsFor(List<UserBirdCollection> collections) {
+        Map<Long, String> result = new LinkedHashMap<>();
+        Map<Long, String> objectKeyMap = collectionImageSelector.selectPrimaryImageKeyMap(collections);
+
+        for (Map.Entry<Long, String> entry : objectKeyMap.entrySet()) {
+            String objectKey = entry.getValue();
+            String thumbnailUrl = objectKey != null ? imageDomainService.toThumbnailUrl(objectKey) : null;
+            result.put(entry.getKey(), thumbnailUrl);
+        }
+
+        return result;
+    }
+
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -60,13 +60,15 @@ public interface CollectionWebMapper {
 
     @Mapping(target = "collectionId", source = "collection.id")
     @Mapping(target = "koreanName", source = "collection.bird.name.koreanName")
+    @Mapping(target = "imageUrl", source = "imageUrl")
+    @Mapping(target = "thumbnailImageUrl", source = "thumbnailUrl")
     @Mapping(target = "likeCount", source = "likeCount")
     @Mapping(target = "commentCount", source = "commentCount")
     @Mapping(target = "isLiked", source = "isLiked")
     @Mapping(target = "user.userId", source = "collection.user.id")
     @Mapping(target = "user.nickname", source = "collection.user.nickname")
     @Mapping(target = "user.profileImageUrl", source = "userProfileImageUrl")
-    GetNearbyCollectionsResponse.Item toGetNearbyCollectionsResponseItem(UserBirdCollection collection, String imageUrl, String userProfileImageUrl, long likeCount, long commentCount, boolean isLiked);
+    GetNearbyCollectionsResponse.Item toGetNearbyCollectionsResponseItem(UserBirdCollection collection, String imageUrl, String thumbnailUrl, String userProfileImageUrl, long likeCount, long commentCount, boolean isLiked);
 
     @Named("getBirdId")
     default Long getBirdId(UserBirdCollection collection) {

--- a/src/main/java/org/devkor/apu/saerok_server/global/shared/infra/ImageDomainService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/shared/infra/ImageDomainService.java
@@ -1,10 +1,14 @@
 package org.devkor.apu.saerok_server.global.shared.infra;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ImageDomainService {
+
+    private final S3ImageService s3ImageService;
 
     @Value("${aws.cloudfront.upload-image-domain}")
     private String uploadImageDomain;
@@ -21,6 +25,10 @@ public class ImageDomainService {
      */
     public String toUploadImageUrl(String objectKey) {
         return uploadImageDomain + "/" + objectKey;
+    }
+
+    public String toThumbnailUrl(String objectKey) {
+        return toUploadImageUrl(s3ImageService.getThumbnailKey(objectKey));
     }
 
     public String toDexImageUrl(String objectKey) {

--- a/src/main/java/org/devkor/apu/saerok_server/global/shared/infra/ImageService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/shared/infra/ImageService.java
@@ -33,4 +33,7 @@ public interface ImageService {
      * @return true면 존재
      */
     boolean exists(String objectKey);
+
+    // 썸네일 url을 만드는 헬퍼
+    String getThumbnailKey(String originalKey);
 }

--- a/src/main/java/org/devkor/apu/saerok_server/global/shared/infra/S3ImageService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/global/shared/infra/S3ImageService.java
@@ -53,6 +53,20 @@ public class S3ImageService implements ImageService {
                     .key(key)
                     .build();
             s3Client.deleteObject(deleteRequest);
+
+            // 썸네일이 있다면, 그것도 삭제
+            if (key.startsWith("collection-images/")) {
+                String thumbnailKey = getThumbnailKey(key);
+                try {
+                    DeleteObjectRequest thumbnailDeleteRequest = DeleteObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(thumbnailKey)
+                            .build();
+                    s3Client.deleteObject(thumbnailDeleteRequest);
+                } catch (S3Exception e) {
+                    log.warn("썸네일 삭제 실패: key={}, code={}", thumbnailKey, e.statusCode());
+                }
+            }
         } catch (S3Exception e) {
             throw new RuntimeException("S3 이미지 삭제 실패: key=" + key, e);
         }
@@ -62,11 +76,19 @@ public class S3ImageService implements ImageService {
     public void deleteAll(List<String> objectKeys) {
         if (objectKeys == null || objectKeys.isEmpty()) return;
 
+        // 원본 키 + 썸네일 키를 모두 포함한 리스트 생성
+        List<String> allKeysToDelete = new ArrayList<>(objectKeys);
+        for (String key : objectKeys) {
+            if (key.startsWith("collection-images/")) {
+                allKeysToDelete.add(getThumbnailKey(key));
+            }
+        }
+
         final int BATCH_SIZE = 1000;
         List<String> hardFailed = new ArrayList<>();
 
-        for (int i = 0; i < objectKeys.size(); i += BATCH_SIZE) {
-            List<String> batch = objectKeys.subList(i, Math.min(i + BATCH_SIZE, objectKeys.size()));
+        for (int i = 0; i < allKeysToDelete.size(); i += BATCH_SIZE) {
+            List<String> batch = allKeysToDelete.subList(i, Math.min(i + BATCH_SIZE, allKeysToDelete.size()));
             List<ObjectIdentifier> toDelete = batch.stream()
                     .map(k -> ObjectIdentifier.builder().key(k).build())
                     .toList();
@@ -128,5 +150,12 @@ public class S3ImageService implements ImageService {
             }
             throw e;
         }
+    }
+
+    @Override
+    public String getThumbnailKey(String originalKey) {
+        String fileName = originalKey.substring(originalKey.lastIndexOf('/') + 1);
+        String fileNameWithoutExt = fileName.replaceFirst("\\.[^.]*$", "");
+        return "thumbnails/" + fileNameWithoutExt + ".webp";
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

성능 개선을 위해, 이미지 업로드 이벤트 발생 시 썸네일을 s3에 만들어서 저장하고, 이후 '내 컬렉션 목록 조회'와 '근처 컬렉션 조회' 시 썸네일 url도 반환합니다.
(추후 프론트에서 필요하다고 하면 커뮤니티에도 도입 가능)

## 📸스크린샷 (선택)

<img width="427" height="241" alt="image" src="https://github.com/user-attachments/assets/7ed3f801-30f3-4922-878d-665d0fe685c0" />


## 💬 공유사항

@soonduck-dreams 
aws 람다를 이용해서 자동화해봤는데, 람다 비용이 많이 나온다면 추후 비동기 서버 연산으로 바꿔볼 예정입니다.
또한 이미 업로드 된 이미지를 썸네일화하는 것은 아직 완료되지 않았는데, 완료한다면 전달드리겠습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.