### PR TITLE
feat(): 새록이 반환되는 모든 응답에 `canSuggestBirdId` 추가

### DIFF
--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/BirdIdSuggestionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/BirdIdSuggestionController.java
@@ -31,7 +31,7 @@ public class BirdIdSuggestionController {
     @PermitAll
     @Operation(
             summary  = "동정 의견을 기다리는 컬렉션 목록 조회",
-            description = "bird_id 미확정 PUBLIC 컬렉션 목록을 조회",
+            description = "bird_id가 미확정이고 동정 의견을 받는 PUBLIC 컬렉션 목록을 조회",
             responses = @ApiResponse(
                     responseCode = "200", description = "조회 성공",
                     content      = @Content(schema = @Schema(implementation = GetPendingCollectionsResponse.class))

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionController.java
@@ -245,6 +245,7 @@ public class CollectionController {
             - commentCount
             - createdAt
             - discoveredDate
+            - canSuggestBirdId
             """,
             responses = {
                     @ApiResponse(

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionLikeController.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/CollectionLikeController.java
@@ -77,7 +77,7 @@ public class CollectionLikeController {
             security = @SecurityRequirement(name = "bearerAuth"),
             description = "내가 좋아요한 컬렉션 목록을 조회합니다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "좋아요한 컬렉션 ID 목록 조회 성공",
+                    @ApiResponse(responseCode = "200", description = "좋아요한 컬렉션 목록 조회 성공",
                             content = @Content(schema = @Schema(implementation = GetLikedCollectionsResponse.class))),
                     @ApiResponse(responseCode = "401", description = "사용자 인증 실패", content = @Content),
                     @ApiResponse(responseCode = "404", description = "사용자가 존재하지 않음", content = @Content)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
@@ -37,9 +37,6 @@ public class GetCollectionEditDataResponse {
     @Schema(description = "birdId가 null일 때 동정 의견을 받을지 여부", example = "true")
     private Boolean birdIdSuggestionEnabled;
 
-    @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true")
-    private Boolean canSuggestBirdId;
-
     @Schema(description = "이미지 ID", example = "300")
     private Long imageId;
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetCollectionEditDataResponse.java
@@ -37,6 +37,9 @@ public class GetCollectionEditDataResponse {
     @Schema(description = "birdId가 null일 때 동정 의견을 받을지 여부", example = "true")
     private Boolean birdIdSuggestionEnabled;
 
+    @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true")
+    private Boolean canSuggestBirdId;
+
     @Schema(description = "이미지 ID", example = "300")
     private Long imageId;
 

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetLikedCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetLikedCollectionsResponse.java
@@ -12,6 +12,9 @@ public record GetLikedCollectionsResponse(
     @Schema(name = "GetLikedCollectionsResponse.Item")
     public record Item(
             @Schema(description = "컬렉션 ID", example = "1")
-            Long collectionId
+            Long collectionId,
+
+            @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true")
+            Boolean canSuggestBirdId
     ) {}
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetNearbyCollectionsResponse.java
@@ -53,6 +53,9 @@ public class GetNearbyCollectionsResponse {
         @Schema(description = "내가 좋아요 눌렀는지 여부", example = "true")
         private Boolean isLiked;
 
+        @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true")
+        private Boolean canSuggestBirdId;
+
         @Schema(description = "컬렉션 소유자 정보")
         private UserInfo user;
     }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetPendingCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/GetPendingCollectionsResponse.java
@@ -32,6 +32,9 @@ public record GetPendingCollectionsResponse(
             String thumbnailProfileImageUrl,
 
             @Schema(description = "동정 의견 요청 시각", example = "2025-07-20T00:23:58.164815", requiredMode = Schema.RequiredMode.REQUIRED)
-            LocalDateTime birdIdSuggestionRequestedAt
+            LocalDateTime birdIdSuggestionRequestedAt,
+
+            @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+            Boolean canSuggestBirdId
     ) {}
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/MyCollectionsResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/MyCollectionsResponse.java
@@ -35,6 +35,9 @@ public record MyCollectionsResponse(
         LocalDateTime createdAt,
 
         @Schema(description = "새 발견 일시", example = "2025-01-15")
-        LocalDate discoveredDate
+        LocalDate discoveredDate,
+
+        @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true")
+        Boolean canSuggestBirdId
     ) { }
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
@@ -37,5 +37,8 @@ public record UpdateCollectionResponse(
         AccessLevelType accessLevel,
 
         @Schema(description = "birdId가 null일 때 동정 의견을 받을지 여부", example = "true")
-        Boolean birdIdSuggestionEnabled
+        Boolean birdIdSuggestionEnabled,
+
+        @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true")
+        Boolean canSuggestBirdId
 ) {}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/api/dto/response/UpdateCollectionResponse.java
@@ -37,8 +37,5 @@ public record UpdateCollectionResponse(
         AccessLevelType accessLevel,
 
         @Schema(description = "birdId가 null일 때 동정 의견을 받을지 여부", example = "true")
-        Boolean birdIdSuggestionEnabled,
-
-        @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true")
-        Boolean canSuggestBirdId
+        Boolean birdIdSuggestionEnabled
 ) {}

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionQueryService.java
@@ -70,7 +70,8 @@ public class BirdIdSuggestionQueryService {
                             thumbnailProfileImageUrls.get(c.getUser().getId()),
                             startedAt != null
                                     ? OffsetDateTimeLocalizer.toSeoulLocalDateTime(startedAt)
-                                    : null
+                                    : null,
+                            c.canReceiveBirdIdSuggestions()
                     );
                 })
                 .toList();

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionLikeQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionLikeQueryService.java
@@ -44,7 +44,7 @@ public class CollectionLikeQueryService {
     }
 
     /**
-     * 사용자가 좋아요한 컬렉션 ID 목록 조회
+     * 사용자가 좋아요한 컬렉션 목록 조회
      */
     public GetLikedCollectionsResponse getLikedCollectionIdsResponse(Long userId) {
         userRepository.findById(userId)

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryService.java
@@ -121,7 +121,8 @@ public class CollectionQueryService {
                             likeCount,
                             commentCount,
                             OffsetDateTimeLocalizer.toSeoulLocalDateTime(c.getCreatedAt()),
-                            c.getDiscoveredDate()
+                            c.getDiscoveredDate(),
+                            c.canReceiveBirdIdSuggestions()
                     );
                 })
                 .toList();

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionLikeWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionLikeWebMapper.java
@@ -16,7 +16,7 @@ import java.util.Map;
 )
 public interface CollectionLikeWebMapper {
 
-    // 좋아요한 컬렉션 ID 목록 조회
+    // 좋아요한 컬렉션 목록 조회
     default GetLikedCollectionsResponse toGetLikedCollectionsResponse(List<UserBirdCollection> collections) {
         if (collections == null || collections.isEmpty()) {
             return new GetLikedCollectionsResponse(List.of());
@@ -29,6 +29,7 @@ public interface CollectionLikeWebMapper {
     List<GetLikedCollectionsResponse.Item> toLikedCollectionItems(List<UserBirdCollection> collections);
 
     @Mapping(target = "collectionId", source = "id")
+    @Mapping(target = "canSuggestBirdId", expression = "java(collection.canReceiveBirdIdSuggestions())")
     GetLikedCollectionsResponse.Item toLikedCollectionItem(UserBirdCollection collection);
 
     // 컬렉션을 좋아요한 사용자 목록 조회

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -38,7 +38,6 @@ public interface CollectionWebMapper {
     GetCollectionEditDataCommand toGetCollectionDataCommand(Long userId, Long collectionId);
 
     @Mapping(target = "birdId", source = "bird.id")
-    @Mapping(target = "canSuggestBirdId", expression = "java(collection.canReceiveBirdIdSuggestions())")
     GetCollectionEditDataResponse toGetCollectionEditDataResponse(UserBirdCollection collection);
 
     @Mapping(target = "userId", source = "userId")
@@ -46,7 +45,6 @@ public interface CollectionWebMapper {
 
     @Mapping(target = "birdId", source = "collection.bird.id")
     @Mapping(target = "collectionId", source = "collection.id")
-    @Mapping(target = "canSuggestBirdId", expression = "java(collection.canReceiveBirdIdSuggestions())")
     UpdateCollectionResponse toUpdateCollectionResponse(UserBirdCollection collection, String imageUrl);
 
     @Mapping(target = "bird.birdId", source = "collection", qualifiedByName = "getBirdId")

--- a/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionWebMapper.java
@@ -38,6 +38,7 @@ public interface CollectionWebMapper {
     GetCollectionEditDataCommand toGetCollectionDataCommand(Long userId, Long collectionId);
 
     @Mapping(target = "birdId", source = "bird.id")
+    @Mapping(target = "canSuggestBirdId", expression = "java(collection.canReceiveBirdIdSuggestions())")
     GetCollectionEditDataResponse toGetCollectionEditDataResponse(UserBirdCollection collection);
 
     @Mapping(target = "userId", source = "userId")
@@ -45,6 +46,7 @@ public interface CollectionWebMapper {
 
     @Mapping(target = "birdId", source = "collection.bird.id")
     @Mapping(target = "collectionId", source = "collection.id")
+    @Mapping(target = "canSuggestBirdId", expression = "java(collection.canReceiveBirdIdSuggestions())")
     UpdateCollectionResponse toUpdateCollectionResponse(UserBirdCollection collection, String imageUrl);
 
     @Mapping(target = "bird.birdId", source = "collection", qualifiedByName = "getBirdId")
@@ -74,6 +76,7 @@ public interface CollectionWebMapper {
     @Mapping(target = "likeCount", source = "likeCount")
     @Mapping(target = "commentCount", source = "commentCount")
     @Mapping(target = "isLiked", source = "isLiked")
+    @Mapping(target = "canSuggestBirdId", expression = "java(collection.canReceiveBirdIdSuggestions())")
     @Mapping(target = "user.userId", source = "collection.user.id")
     @Mapping(target = "user.nickname", source = "collection.user.nickname")
     @Mapping(target = "user.profileImageUrl", source = "userProfileImageUrl")

--- a/src/main/java/org/devkor/apu/saerok_server/domain/profile/api/dto/response/UserProfileResponse.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/profile/api/dto/response/UserProfileResponse.java
@@ -54,6 +54,9 @@ public record UserProfileResponse(
             LocalDate discoveredDate,
 
             @Schema(description = "컬렉션을 업로드한 날짜", example = "2025-05-17", requiredMode = Schema.RequiredMode.REQUIRED)
-            LocalDate uploadedDate
+            LocalDate uploadedDate,
+
+            @Schema(description = "동정 의견을 받을 수 있는 상태인지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+            Boolean canSuggestBirdId
     ) {}
 }

--- a/src/main/java/org/devkor/apu/saerok_server/domain/profile/mapper/UserProfileMapper.java
+++ b/src/main/java/org/devkor/apu/saerok_server/domain/profile/mapper/UserProfileMapper.java
@@ -55,7 +55,8 @@ public interface UserProfileMapper {
                         thumbnailUrlMap.get(c.getId()),
                         c.getNote(),
                         c.getDiscoveredDate(),
-                        OffsetDateTimeLocalizer.toSeoulLocalDate(c.getCreatedAt())
+                        OffsetDateTimeLocalizer.toSeoulLocalDate(c.getCreatedAt()),
+                        c.canReceiveBirdIdSuggestions()
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionQueryServiceTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/BirdIdSuggestionQueryServiceTest.java
@@ -3,6 +3,7 @@ package org.devkor.apu.saerok_server.domain.collection.application;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetBirdIdSuggestionsResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetPendingCollectionsResponse;
 import org.devkor.apu.saerok_server.domain.collection.application.helper.CollectionImageUrlService;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.BirdIdSuggestionRepository;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.CollectionRepository;
@@ -69,6 +70,7 @@ class BirdIdSuggestionQueryServiceTest {
         setField(c, "id", id);
         setField(c, "user", owner);
         setField(c, "note", note);
+        c.setAccessLevel(AccessLevelType.PUBLIC);
         // birdIdSuggestionRequestedAt 필드는 제거되었으므로 더 이상 세팅하지 않음
         return c;
     }
@@ -123,12 +125,14 @@ class BirdIdSuggestionQueryServiceTest {
             assertThat(first.imageUrl()).isEqualTo("http://cdn/img/thumb/key1.jpg");
             assertThat(first.profileImageUrl()).isEqualTo("http://cdn/profile/1/profile.jpg");
             assertThat(first.thumbnailProfileImageUrl()).isEqualTo("http://cdn/profile/1/thumbnail.webp");
+            assertThat(first.canSuggestBirdId()).isTrue();
 
             GetPendingCollectionsResponse.Item second = res.items().get(1);
             assertThat(second.collectionId()).isEqualTo(2L);
             assertThat(second.imageUrl()).isNull();
             assertThat(second.profileImageUrl()).isEqualTo("http://cdn/profile/default/default-1.png");
             assertThat(second.thumbnailProfileImageUrl()).isEqualTo("http://cdn/profile/default/thumbnail-1.webp");
+            assertThat(second.canSuggestBirdId()).isTrue();
 
             // 히스토리 조회가 호출됐는지까지 확인
             verify(birdIdRequestHistoryRepository).findOpenStartedAtMapByCollectionIds(List.of(1L, 2L));

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryServiceTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/application/CollectionQueryServiceTest.java
@@ -1,10 +1,12 @@
 package org.devkor.apu.saerok_server.domain.collection.application;
 
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionDetailResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.MyCollectionsResponse;
 import org.devkor.apu.saerok_server.domain.collection.application.helper.CollectionImageUrlService;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
 import org.devkor.apu.saerok_server.domain.collection.core.repository.*;
+import org.devkor.apu.saerok_server.domain.collection.core.util.PointFactory;
 import org.devkor.apu.saerok_server.domain.collection.mapper.CollectionWebMapper;
 import org.devkor.apu.saerok_server.domain.user.core.entity.User;
 import org.devkor.apu.saerok_server.domain.user.core.repository.UserRepository;
@@ -22,9 +24,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -211,5 +216,45 @@ class CollectionQueryServiceTest {
 
         assertThrows(NotFoundException.class,
                 () -> collectionQueryService.getCollectionDetailResponse(badUserId, collectionId));
+    }
+
+    @Test
+    @DisplayName("내 컬렉션 목록에 동정 의견 가능 여부를 포함한다")
+    void getMyCollections_includesCanSuggestBirdId() throws IllegalAccessException {
+        Long userId = 1L;
+        User owner = new User();
+        userIdField.set(owner, userId);
+
+        UserBirdCollection enabled = UserBirdCollection.builder()
+                .user(owner)
+                .discoveredDate(LocalDate.of(2026, 7, 22))
+                .location(PointFactory.create(37.5, 127.0))
+                .accessLevel(AccessLevelType.PUBLIC)
+                .birdIdSuggestionEnabled(true)
+                .build();
+        collectionIdField.set(enabled, 1L);
+        org.springframework.test.util.ReflectionTestUtils.setField(enabled, "createdAt", OffsetDateTime.now());
+
+        UserBirdCollection disabled = UserBirdCollection.builder()
+                .user(owner)
+                .discoveredDate(LocalDate.of(2026, 7, 21))
+                .location(PointFactory.create(37.5, 127.0))
+                .accessLevel(AccessLevelType.PUBLIC)
+                .birdIdSuggestionEnabled(false)
+                .build();
+        collectionIdField.set(disabled, 2L);
+        org.springframework.test.util.ReflectionTestUtils.setField(disabled, "createdAt", OffsetDateTime.now());
+
+        List<UserBirdCollection> collections = List.of(enabled, disabled);
+        given(userRepository.findById(userId)).willReturn(Optional.of(owner));
+        given(collectionRepository.findByUserId(userId)).willReturn(collections);
+        given(collectionImageUrlService.getPrimaryImageUrlsFor(collections)).willReturn(Map.of());
+        given(collectionImageUrlService.getPrimaryImageThumbnailUrlsFor(collections)).willReturn(Map.of());
+
+        MyCollectionsResponse response = collectionQueryService.getMyCollections(userId);
+
+        assertThat(response.items())
+                .extracting(MyCollectionsResponse.Item::canSuggestBirdId)
+                .containsExactly(true, false);
     }
 }

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionSuggestionFlagMapperTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionSuggestionFlagMapperTest.java
@@ -1,0 +1,86 @@
+package org.devkor.apu.saerok_server.domain.collection.mapper;
+
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionDetailResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionEditDataResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetLikedCollectionsResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetNearbyCollectionsResponse;
+import org.devkor.apu.saerok_server.domain.collection.api.dto.response.UpdateCollectionResponse;
+import org.devkor.apu.saerok_server.domain.collection.application.helper.CollectionImageUrlService;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
+import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
+import org.devkor.apu.saerok_server.domain.collection.core.util.PointFactory;
+import org.devkor.apu.saerok_server.domain.profile.api.dto.response.UserProfileResponse;
+import org.devkor.apu.saerok_server.domain.profile.mapper.UserProfileMapper;
+import org.devkor.apu.saerok_server.domain.user.core.entity.User;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class CollectionSuggestionFlagMapperTest {
+
+    private final CollectionWebMapper collectionWebMapper = Mappers.getMapper(CollectionWebMapper.class);
+    private final CollectionLikeWebMapper collectionLikeWebMapper = Mappers.getMapper(CollectionLikeWebMapper.class);
+    private final UserProfileMapper userProfileMapper = Mappers.getMapper(UserProfileMapper.class);
+
+    @Test
+    void collectionResponsesMapCanSuggestBirdIdFromCollectionState() {
+        UserBirdCollection collection = suggestionEnabledCollection();
+
+        GetCollectionDetailResponse detail = collectionWebMapper.toGetCollectionDetailResponse(
+                collection, null, null, null, 0, 0, false, true
+        );
+        GetCollectionEditDataResponse editData = collectionWebMapper.toGetCollectionEditDataResponse(collection);
+        UpdateCollectionResponse update = collectionWebMapper.toUpdateCollectionResponse(collection, null);
+        GetNearbyCollectionsResponse.Item nearby = collectionWebMapper.toGetNearbyCollectionsResponseItem(
+                collection, null, null, null, null, 0, 0, false, true
+        );
+        GetLikedCollectionsResponse.Item liked = collectionLikeWebMapper.toLikedCollectionItem(collection);
+
+        assertThat(detail.getCanSuggestBirdId()).isTrue();
+        assertThat(editData.getCanSuggestBirdId()).isTrue();
+        assertThat(update.canSuggestBirdId()).isTrue();
+        assertThat(nearby.getCanSuggestBirdId()).isTrue();
+        assertThat(liked.canSuggestBirdId()).isTrue();
+    }
+
+    @Test
+    void profileCollectionItemsMapCanSuggestBirdIdFromCollectionState() {
+        UserBirdCollection collection = suggestionEnabledCollection();
+        CollectionImageUrlService imageUrlService = mock(CollectionImageUrlService.class);
+        given(imageUrlService.getPrimaryImageUrlsFor(List.of(collection))).willReturn(Map.of());
+        given(imageUrlService.getPrimaryImageThumbnailUrlsFor(List.of(collection))).willReturn(Map.of());
+
+        List<UserProfileResponse.CollectionItem> items =
+                userProfileMapper.toCollectionItems(List.of(collection), imageUrlService);
+
+        assertThat(items).singleElement()
+                .extracting(UserProfileResponse.CollectionItem::canSuggestBirdId)
+                .isEqualTo(true);
+    }
+
+    private UserBirdCollection suggestionEnabledCollection() {
+        User owner = new User();
+        ReflectionTestUtils.setField(owner, "id", 10L);
+
+        UserBirdCollection collection = UserBirdCollection.builder()
+                .user(owner)
+                .bird(null)
+                .discoveredDate(LocalDate.of(2026, 7, 22))
+                .location(PointFactory.create(37.5, 127.0))
+                .accessLevel(AccessLevelType.PUBLIC)
+                .birdIdSuggestionEnabled(true)
+                .build();
+        ReflectionTestUtils.setField(collection, "id", 1L);
+        ReflectionTestUtils.setField(collection, "createdAt", OffsetDateTime.now());
+        return collection;
+    }
+}

--- a/src/test/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionSuggestionFlagMapperTest.java
+++ b/src/test/java/org/devkor/apu/saerok_server/domain/collection/mapper/CollectionSuggestionFlagMapperTest.java
@@ -1,10 +1,8 @@
 package org.devkor.apu.saerok_server.domain.collection.mapper;
 
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionDetailResponse;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetCollectionEditDataResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetLikedCollectionsResponse;
 import org.devkor.apu.saerok_server.domain.collection.api.dto.response.GetNearbyCollectionsResponse;
-import org.devkor.apu.saerok_server.domain.collection.api.dto.response.UpdateCollectionResponse;
 import org.devkor.apu.saerok_server.domain.collection.application.helper.CollectionImageUrlService;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.AccessLevelType;
 import org.devkor.apu.saerok_server.domain.collection.core.entity.UserBirdCollection;
@@ -38,16 +36,12 @@ class CollectionSuggestionFlagMapperTest {
         GetCollectionDetailResponse detail = collectionWebMapper.toGetCollectionDetailResponse(
                 collection, null, null, null, 0, 0, false, true
         );
-        GetCollectionEditDataResponse editData = collectionWebMapper.toGetCollectionEditDataResponse(collection);
-        UpdateCollectionResponse update = collectionWebMapper.toUpdateCollectionResponse(collection, null);
         GetNearbyCollectionsResponse.Item nearby = collectionWebMapper.toGetNearbyCollectionsResponseItem(
                 collection, null, null, null, null, 0, 0, false, true
         );
         GetLikedCollectionsResponse.Item liked = collectionLikeWebMapper.toLikedCollectionItem(collection);
 
         assertThat(detail.getCanSuggestBirdId()).isTrue();
-        assertThat(editData.getCanSuggestBirdId()).isTrue();
-        assertThat(update.canSuggestBirdId()).isTrue();
         assertThat(nearby.getCanSuggestBirdId()).isTrue();
         assertThat(liked.canSuggestBirdId()).isTrue();
     }


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 새록(collection)이 반환되는 모든 응답에 `canSuggestBirdId`를 추가했습니다.
- 이제, 생성 및 수정되는 요청/응답에는 `birdIdSuggestionEnabled`, 조회용 상세 및 목록 응답에는 `canSuggestBirdId`가 반환되어 동정 요청을 받을 수 있는 새록인지 알 수 있습니다.

## 📸스크린샷 (선택)

<!--- 변경 사항을 직관적으로 보여줄 수 있다면 스크린샷을 넣어주세요. -->

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [✅] PR 제목을 커밋 메시지 컨벤션에 맞게 작성했습니다.